### PR TITLE
Example for simple token script

### DIFF
--- a/examples/smart_contracts/simple_token.py
+++ b/examples/smart_contracts/simple_token.py
@@ -1,7 +1,7 @@
 from eopsin.prelude import *
 
 
-def validator(datum: None, redeemer: None, context: ScriptContext) -> None:
+def validator(redeemer: None, context: ScriptContext) -> None:
     purpose = context.purpose
     # whenever tokens should be burned/minted, the minting purpose will be triggered
     if isinstance(purpose, Minting):
@@ -14,7 +14,8 @@ def validator(datum: None, redeemer: None, context: ScriptContext) -> None:
         # in this case simply checking the pubkeyhash of the owner
         # TODO replace this with your own pubkeyhash!
         assert (
-            b"00000000000000000000000000000000000000000000000000000000"
+            # bytes.fromhex("dc315c289fee4484eda07038393f21dc4e572aff292d7926018725c2")
+            b"\xdc1\\(\x9f\xeeD\x84\xed\xa0p89?!\xdcNW*\xff)-y&\x01\x87%\xc2"
             in context.tx_info.signatories
         ), "Required pubkeyhash missing"
     else:

--- a/examples/smart_contracts/simple_token.py
+++ b/examples/smart_contracts/simple_token.py
@@ -1,0 +1,22 @@
+from eopsin.prelude import *
+
+
+def validator(datum: None, redeemer: None, context: ScriptContext) -> None:
+    purpose = context.purpose
+    # whenever tokens should be burned/minted, the minting purpose will be triggered
+    if isinstance(purpose, Minting):
+        own_pid = purpose.policy_id
+    else:
+        assert False, "Wrong redeeming purpose"
+    # if any of the tokens in the list is going to be minted (positive minting amount)
+    if any([x > 0 for x in context.tx_info.mint.get(own_pid, {b"": 0}).values()]):
+        # check the script condition
+        # in this case simply checking the pubkeyhash of the owner
+        # TODO replace this with your own pubkeyhash!
+        assert (
+            b"00000000000000000000000000000000000000000000000000000000"
+            in context.tx_info.signatories
+        ), "Required pubkeyhash missing"
+    else:
+        # we always allow burning!
+        pass


### PR DESCRIPTION
A possible solution (draft) for https://github.com/cardano-foundation/CIPs/pull/392

This compiles to a tiny (1500 bytes(!)) script to be executed in place of a native script that does the same. [Plutonomy-cli ](https://github.com/ImperatorLang/plutonomy-cli)squenches this down another 50% to 750 bytes.

The transaction cost is also minimal. 0.23 ADA, even when the script is included in the transaction. This is hardly more than required for any native scripts (minting [preprod MILK here](https://preprod.cardanoscan.io/transaction/6b5ffd3fb3dafec8c867b2167670ddc76aaba86392291dcd2fa4f2c84d760388) cost 0.18 ADA, so 0.05 ADA difference, pretty much negligible)

https://preprod.cardanoscan.io/transaction/a07c845e6665eb2ba840c888098eb66062eef2a49bba69237f32e970223d5baf