### PR TITLE
Simple script emulator

### DIFF
--- a/eopsin/typed_ast.py
+++ b/eopsin/typed_ast.py
@@ -1023,7 +1023,7 @@ def empty_list(p: Type):
         return plt.EmptyListList(uplc.BuiltinList([], el.sample_value))
     if isinstance(p.typ, DictType):
         plt.EmptyDataPairList()
-    if isinstance(p.typ, RecordType):
+    if isinstance(p.typ, RecordType) or isinstance(p.typ, AnyType):
         return plt.EmptyDataList()
     raise NotImplementedError(f"Empty lists of type {p} can't be constructed yet")
 

--- a/examples/smart_contracts/simple_script.py
+++ b/examples/smart_contracts/simple_script.py
@@ -1,0 +1,90 @@
+from eopsin.prelude import *
+
+
+@dataclass()
+class RequireSignature(PlutusData):
+    CONSTR_ID = 0
+    vkeyhash: bytes  # this is either a PubKeyHash or a VerificationKeyHash
+
+
+@dataclass()
+class RequireAllOf(PlutusData):
+    CONSTR_ID = 1
+    scripts: List["Script"]
+
+
+@dataclass()
+class RequireAnyOf(PlutusData):
+    CONSTR_ID = 2
+    scripts: List["Script"]
+
+
+@dataclass()
+class RequireMOf(PlutusData):
+    CONSTR_ID = 3
+    num: int
+    scripts: List["Script"]
+
+
+@dataclass()
+class RequireBefore(PlutusData):
+    CONSTR_ID = 4
+    unixtimestamp: int
+
+
+@dataclass()
+class RequireAfter(PlutusData):
+    CONSTR_ID = 5
+    unixtimestamp: int
+
+
+Script = Union[
+    RequireSignature,
+    RequireMOf,
+    RequireAnyOf,
+    RequireAllOf,
+    RequireAfter,
+    RequireBefore,
+]
+
+
+def validate_script(
+    script: Script, signatories: List[bytes], valid_range: POSIXTimeRange
+) -> bool:
+    if isinstance(script, RequireSignature):
+        res = script.vkeyhash in signatories
+    elif isinstance(script, RequireAllOf):
+        res = all(
+            [validate_script(s, signatories, valid_range) for s in script.scripts]
+        )
+    elif isinstance(script, RequireAnyOf):
+        res = any(
+            [validate_script(s, signatories, valid_range) for s in script.scripts]
+        )
+    elif isinstance(script, RequireMOf):
+        res = (
+            sum(
+                [
+                    int(validate_script(s, signatories, valid_range))
+                    for s in script.scripts
+                ]
+            )
+            >= script.num
+        )
+    elif isinstance(script, RequireBefore):
+        res = valid_range.upper_bound < script.unixtimestamp
+    elif isinstance(script, RequireAfter):
+        res = valid_range.lower_bound > script.unixtimestamp
+    else:
+        assert False, "Invalid simple script passed"
+    return res
+
+
+# to fully emulate simple script behaviour, compile with --force-three-params
+# the script is a contract parameter, pass it into the build command
+def validator(
+    script: Script, datum: None, redeemer: None, context: ScriptContext
+) -> None:
+    assert validate_script(
+        script, context.tx_info.signatories, context.tx_info.valid_range
+    ), "Simple Script validation failed!"

--- a/examples/smart_contracts/simple_script.py
+++ b/examples/smart_contracts/simple_script.py
@@ -10,20 +10,20 @@ class RequireSignature(PlutusData):
 @dataclass()
 class RequireAllOf(PlutusData):
     CONSTR_ID = 1
-    scripts: List["Script"]
+    scripts: List[Datum]  # "Script"
 
 
 @dataclass()
 class RequireAnyOf(PlutusData):
     CONSTR_ID = 2
-    scripts: List["Script"]
+    scripts: List[Datum]  # "Script"
 
 
 @dataclass()
 class RequireMOf(PlutusData):
     CONSTR_ID = 3
     num: int
-    scripts: List["Script"]
+    scripts: List[Datum]  # "Script"
 
 
 @dataclass()
@@ -49,8 +49,9 @@ Script = Union[
 
 
 def validate_script(
-    script: Script, signatories: List[bytes], valid_range: POSIXTimeRange
+    script_raw: Datum, signatories: List[bytes], valid_range: POSIXTimeRange
 ) -> bool:
+    script: Script = script_raw  # cast to Script in the type system to avoid recursive type definition
     if isinstance(script, RequireSignature):
         res = script.vkeyhash in signatories
     elif isinstance(script, RequireAllOf):
@@ -65,7 +66,7 @@ def validate_script(
         res = (
             sum(
                 [
-                    int(validate_script(s, signatories, valid_range))
+                    1 if validate_script(s, signatories, valid_range) else 0
                     for s in script.scripts
                 ]
             )

--- a/examples/smart_contracts/simple_script.py
+++ b/examples/smart_contracts/simple_script.py
@@ -73,9 +73,31 @@ def validate_script(
             >= script.num
         )
     elif isinstance(script, RequireBefore):
-        res = valid_range.upper_bound < script.unixtimestamp
+        upper_bound = valid_range.upper_bound
+        upper_limit = upper_bound.limit
+        if isinstance(upper_limit, FinitePOSIXTime):
+            upper_closed = upper_bound.closed
+            if isinstance(upper_closed, TrueData):
+                res = upper_limit.time <= script.unixtimestamp
+            else:
+                res = upper_limit.time < script.unixtimestamp
+        elif isinstance(upper_limit, PosInfPOSIXTime):
+            res = False
+        elif isinstance(upper_limit, NegInfPOSIXTime):
+            res = True
     elif isinstance(script, RequireAfter):
-        res = valid_range.lower_bound > script.unixtimestamp
+        lower_bound = valid_range.lower_bound
+        lower_limit = lower_bound.limit
+        if isinstance(lower_limit, FinitePOSIXTime):
+            lower_closed = lower_bound.closed
+            if isinstance(lower_closed, TrueData):
+                res = lower_limit.time >= script.unixtimestamp
+            else:
+                res = lower_limit.time > script.unixtimestamp
+        elif isinstance(lower_limit, PosInfPOSIXTime):
+            res = True
+        elif isinstance(lower_limit, NegInfPOSIXTime):
+            res = False
     else:
         assert False, "Invalid simple script passed"
     return res


### PR DESCRIPTION
This implements a full powered emulator for simple scripts as described in https://github.com/input-output-hk/cardano-node/blob/master/doc/reference/simple-scripts.md

The use case here is to enable users to port over their simple scripts + supercharging them with plutus functions i.e. always allow burning as described here: https://github.com/cardano-foundation/CIPs/pull/392#issuecomment-1450969771

The simple script is a script parameter that is passed at compile time and evaluated by the smart contract on invocation. The script is able to handle minting, spending, certification etc just as native scripts