### PR TITLE
Create releases automatically

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,6 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # If there isn't a release for this version, create a new one.
+      - uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          makeLatest: true
+          prerelease: true
+          skipIfReleaseExists: true
+      # Build and publish the package to pypi.
       - name: Build and publish to pypi
         uses: JRubics/poetry-publish@v1.16
         with:


### PR DESCRIPTION
I added an action that makes a github release automatically when you push to the release tag.
https://github.com/ncipollo/release-action

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes