### PR TITLE
Introduce dict.items and allow tuple deconstruction in for loops

### DIFF
--- a/opshin/rewrite/rewrite_tuple_assign.py
+++ b/opshin/rewrite/rewrite_tuple_assign.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 import typing
 from ast import *
 
@@ -33,3 +35,31 @@ class RewriteTupleAssign(CompilingNodeTransformer):
         # recursively resolve multiple layers of tuples
         transformed = sum([self.visit(a) for a in assignments], [])
         return transformed
+
+    def visit_For(self, node: For) -> For:
+        # rewrite deconstruction in for loops
+        if not isinstance(node.target, Tuple):
+            return node
+        new_for = copy(node)
+        new_for.iter = self.visit(node.iter)
+        uid = self.unique_id
+        self.unique_id += 1
+        # write the tuple into a singleton variable
+        new_for.target = Name(f"{uid}_tup", Store())
+        assignments = []
+        # iteratively assign the deconstructed parts to the original variable names
+        for i, t in enumerate(node.target.elts):
+            assignments.append(
+                Assign(
+                    [t],
+                    Subscript(
+                        value=Name(f"{uid}_tup", Load()),
+                        slice=Constant(i),
+                        ctx=Load(),
+                    ),
+                )
+            )
+        new_for.body = assignments + node.body
+        # recursively resolve multiple layers of tuples
+        # further layers should be handled by the normal tuple assignment though
+        return self.visit(new_for)

--- a/opshin/rewrite/rewrite_tuple_assign.py
+++ b/opshin/rewrite/rewrite_tuple_assign.py
@@ -39,7 +39,7 @@ class RewriteTupleAssign(CompilingNodeTransformer):
     def visit_For(self, node: For) -> For:
         # rewrite deconstruction in for loops
         if not isinstance(node.target, Tuple):
-            return node
+            return self.generic_visit(node)
         new_for = copy(node)
         new_for.iter = self.visit(node.iter)
         uid = self.unique_id

--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -861,3 +861,23 @@ def validator(xs: Dict[int, bytes]) -> bytes:
             b"".join(xs.values()),
             "for loop deconstruction did not behave as expected",
         )
+
+    def test_nested_deconstruction(self):
+        # asserts that deconstruction of parameters works for for loops too
+        source_code = """
+def validator(xs) -> int:
+    a, ((b, c), d) = (1, ((2, 3), 4))
+    return a + b + c + d
+"""
+        ast = compiler.parse(source_code)
+        code = compiler.compile(ast)
+        code = code.compile()
+        f = code.term
+        # UPLC lambdas may only take one argument at a time, so we evaluate by repeatedly applying
+        f = uplc.Apply(f, uplc.PlutusConstr(0, []))
+        ret = uplc_eval(f).value
+        self.assertEqual(
+            ret,
+            1 + 2 + 3 + 4,
+            "for loop deconstruction did not behave as expected",
+        )

--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -881,7 +881,13 @@ def validator(xs) -> int:
             "for loop deconstruction did not behave as expected",
         )
 
-    @given(xs=st.dictionaries(st.binary(), st.dictionaries(st.binary(), st.integers())))
+    @given(
+        xs=st.dictionaries(
+            st.binary(),
+            st.dictionaries(st.binary(), st.integers(), max_size=3),
+            max_size=5,
+        )
+    )
     def test_dict_items_values_deconstr(self, xs):
         # nested deconstruction with a Value-like object
         source_code = """

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -421,7 +421,18 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
                 ts.typ = ts.value.typ.typ.typs[ts.slice.value]
             else:
                 raise TypeInferenceError(
-                    f"Could not infer type of subscript of typ {ts.value.typ.__class__}"
+                    f"Could not infer type of subscript of typ {ts.value.typ.typ.__class__}"
+                )
+        elif isinstance(ts.value.typ.typ, PairType):
+            if isinstance(ts.slice, Constant) and isinstance(ts.slice.value, int):
+                ts.typ = (
+                    ts.value.typ.typ.l_typ
+                    if ts.slice.value == 0
+                    else ts.value.typ.typ.r_typ
+                )
+            else:
+                raise TypeInferenceError(
+                    f"Could not infer type of subscript of typ {ts.value.typ.typ.__class__}"
                 )
         elif isinstance(ts.value.typ.typ, ListType):
             ts.typ = ts.value.typ.typ.typ


### PR DESCRIPTION
With these changes the following code becomes valid

```python
def validator(xs: Dict[int, bytes]) -> bytes:
    sum_values = b""
    for _, x in xs.items():
        sum_values += x
    return sum_values
```

Resolves https://github.com/OpShin/opshin-pioneer-program/pull/25#issuecomment-1493038970