### PR TITLE
Feat/simplify interval

### DIFF
--- a/opshin/ledger/interval.py
+++ b/opshin/ledger/interval.py
@@ -73,7 +73,7 @@ def compare_lower_bound(a: LowerBoundPOSIXTime, b: LowerBoundPOSIXTime) -> int:
 
 
 def contains(a: POSIXTimeRange, b: POSIXTimeRange) -> bool:
-    # Returns True if the interval `b` is entirely contained in `a`.
+    """Returns True if the interval `b` is entirely contained in `a`."""
     lower = compare_lower_bound(a.lower_bound, b.lower_bound)
     upper = compare_upper_bound(a.upper_bound, b.upper_bound)
     return (lower == 1 or lower == 0) and (upper == 0 or upper == -1)
@@ -82,24 +82,29 @@ def contains(a: POSIXTimeRange, b: POSIXTimeRange) -> bool:
 def make_range(
     lower_bound: POSIXTime,
     upper_bound: POSIXTime,
-    lower_closed: BoolData,
-    upper_closed: BoolData,
 ) -> POSIXTimeRange:
+    """
+    Create a bounded interval from the given time `lower_bound` up to the given `upper_bound`, including the given time
+    """
     return POSIXTimeRange(
-        LowerBoundPOSIXTime(FinitePOSIXTime(lower_bound), lower_closed),
-        UpperBoundPOSIXTime(FinitePOSIXTime(upper_bound), upper_closed),
+        LowerBoundPOSIXTime(FinitePOSIXTime(lower_bound), TrueData()),
+        UpperBoundPOSIXTime(FinitePOSIXTime(upper_bound), TrueData()),
     )
 
 
-def make_from(lower_bound: POSIXTime, lower_closed: BoolData) -> POSIXTimeRange:
+def make_from(lower_bound: POSIXTime) -> POSIXTimeRange:
+    """Create a bounded interval from the given time `lower_bound` up to infinity, including the given time"""
     return POSIXTimeRange(
-        LowerBoundPOSIXTime(FinitePOSIXTime(lower_bound), lower_closed),
+        LowerBoundPOSIXTime(FinitePOSIXTime(lower_bound), TrueData()),
         UpperBoundPOSIXTime(PosInfPOSIXTime(), TrueData()),
     )
 
 
-def make_to(upper_bound: POSIXTime, upper_closed: BoolData) -> POSIXTimeRange:
+def make_to(upper_bound: POSIXTime) -> POSIXTimeRange:
+    """
+    Create a bounded interval from negative infinity up to the given `upper_bound`, including the given time
+    """
     return POSIXTimeRange(
         LowerBoundPOSIXTime(NegInfPOSIXTime(), TrueData()),
-        UpperBoundPOSIXTime(FinitePOSIXTime(upper_bound), upper_closed),
+        UpperBoundPOSIXTime(FinitePOSIXTime(upper_bound), TrueData()),
     )

--- a/opshin/tests/test_ledger/test_interval.py
+++ b/opshin/tests/test_ledger/test_interval.py
@@ -147,44 +147,34 @@ def test_contains(a: POSIXTimeRange, b: POSIXTimeRange):
 
 @given(
     lower_bound=st.integers(),
-    lower_closed=st.one_of(st.builds(FalseData), st.builds(TrueData)),
 )
 def test_fuzz_make_from(
     lower_bound: int,
-    lower_closed: BoolData,
 ) -> None:
-    make_from(lower_bound=lower_bound, lower_closed=lower_closed)
+    make_from(lower_bound=lower_bound)
 
 
 @given(
     lower_bound=st.integers(),
     upper_bound=st.integers(),
-    lower_closed=st.one_of(st.builds(FalseData), st.builds(TrueData)),
-    upper_closed=st.one_of(st.builds(FalseData), st.builds(TrueData)),
 )
 def test_fuzz_make_range(
     lower_bound: int,
     upper_bound: int,
-    lower_closed: BoolData,
-    upper_closed: BoolData,
 ) -> None:
     make_range(
         lower_bound=lower_bound,
         upper_bound=upper_bound,
-        lower_closed=lower_closed,
-        upper_closed=upper_closed,
     )
 
 
 @given(
     upper_bound=st.integers(),
-    upper_closed=st.one_of(st.builds(FalseData), st.builds(TrueData)),
 )
 def test_fuzz_make_to(
     upper_bound: int,
-    upper_closed: BoolData,
 ) -> None:
-    make_to(upper_bound=upper_bound, upper_closed=upper_closed)
+    make_to(upper_bound=upper_bound)
 
 
 @given(

--- a/opshin/tests/test_ledger/test_interval.py
+++ b/opshin/tests/test_ledger/test_interval.py
@@ -195,3 +195,33 @@ def test_get_bool(b: bool) -> None:
     else:
         bool_data = FalseData()
     assert get_bool(bool_data) == b
+
+
+@given(
+    lower_bound=st.integers(),
+    upper_bound_1=st.integers(),
+    upper_bound_2=st.integers(),
+)
+def test_make_to_in_make_range(
+    lower_bound: int,
+    upper_bound_1: int,
+    upper_bound_2: int,
+) -> None:
+    assert contains(
+        make_to(upper_bound=upper_bound_1), make_range(lower_bound, upper_bound_2)
+    ) == (upper_bound_1 >= upper_bound_2)
+
+
+@given(
+    lower_bound_1=st.integers(),
+    lower_bound_2=st.integers(),
+    upper_bound=st.integers(),
+)
+def test_make_from_in_make_range(
+    lower_bound_1: int,
+    lower_bound_2: int,
+    upper_bound: int,
+) -> None:
+    assert contains(
+        make_from(lower_bound=lower_bound_1), make_range(lower_bound_2, upper_bound)
+    ) == (lower_bound_1 <= lower_bound_2)


### PR DESCRIPTION
@juliusfrost would be interested to have your opinion on this

Technically you can specify whether an interval is open/closed but I am wondering if this is really interesting? Unixtimestamps are in the precision of microseconds, I don't think it really matters in any real-world use case whether the interval is closed or open (when creating them, for comparison we need to take it into account for completeness)