### PR TITLE
Split building and artifacts creation

### DIFF
--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -176,7 +176,7 @@ Note that opshin errors may be overly restrictive as they aim to prevent code wi
         else:
             target_dir = pathlib.Path(args.output_directory)
         target_dir.mkdir(exist_ok=True, parents=True)
-        artifacts = builder._build(code)
+        artifacts = builder.generate_artifacts(builder._build(code))
         with (target_dir / "script.cbor").open("w") as fp:
             fp.write(artifacts.cbor_hex)
         with (target_dir / "script.plutus").open("w") as fp:

--- a/opshin/builder.py
+++ b/opshin/builder.py
@@ -48,9 +48,13 @@ def build(
 def _build(contract: uplc.ast.Program):
     # create cbor file for use with pycardano/lucid
     cbor = flatten(contract)
-    cbor_hex = cbor.hex()
+    return pycardano.PlutusV2Script(cbor)
+
+
+def generate_artifacts(contract: pycardano.PlutusV2Script):
+    cbor_hex = contract.hex()
     # double wrap
-    cbor_wrapped = cbor2.dumps(cbor)
+    cbor_wrapped = cbor2.dumps(contract)
     cbor_wrapped_hex = cbor_wrapped.hex()
     # create plutus file
     d = {
@@ -59,7 +63,7 @@ def _build(contract: uplc.ast.Program):
         "cborHex": cbor_wrapped_hex,
     }
     plutus_json = json.dumps(d, indent=2)
-    script_hash = pycardano.plutus_script_hash(pycardano.PlutusV2Script(cbor))
+    script_hash = pycardano.plutus_script_hash(pycardano.PlutusV2Script(contract))
     policy_id = script_hash.to_primitive().hex()
     # generate policy ids
     addr_mainnet = pycardano.Address(


### PR DESCRIPTION
The builder code now differentiates between creating a pycardano PlutusV2Script object and building artifacts for external usage