### PR TITLE
Add a linter

### DIFF
--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -145,7 +145,7 @@ def main():
             if args.output_format_json:
                 print(
                     convert_linter_to_json(
-                        line=start_line + 1,
+                        line=start_line,
                         column=pos_in_line,
                         error_class=c.orig_err.__class__.__name__,
                         message=str(c.orig_err),
@@ -236,16 +236,18 @@ def convert_linter_to_json(
 ):
     # output in lists
     # TODO: possible to detect more than one error at once?
-    return [
-        {
-            "line": line,
-            "column": column,
-            "error_class": error_class,
-            "message": message,
-            "end_line": end_line,
-            "end_column": end_column,
-        }
-    ]
+    return json.dumps(
+        [
+            {
+                "line": line,
+                "column": column,
+                "error_class": error_class,
+                "message": message,
+                "end_line": end_line,
+                "end_column": end_column,
+            }
+        ]
+    )
 
 
 if __name__ == "__main__":

--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -145,10 +145,10 @@ def main():
             if args.output_format_json:
                 print(
                     convert_linter_to_json(
-                        start_line,
-                        pos_in_line,
-                        c.orig_err.__class__.__name__,
-                        str(c.orig_err),
+                        line=start_line + 1,
+                        column=pos_in_line,
+                        error_class=c.orig_err.__class__.__name__,
+                        message=str(c.orig_err),
                     )
                 )
             else:
@@ -226,15 +226,26 @@ Note that opshin errors may be overly restrictive as they aim to prevent code wi
         print(ret)
 
 
-def convert_linter_to_json(line: int, column: int, error_class: str, message: str):
+def convert_linter_to_json(
+    line: int,
+    column: int,
+    error_class: str,
+    message: str,
+    end_line: int | None = None,
+    end_column: int | None = None,
+):
     # output in lists
     # TODO: possible to detect more than one error at once?
-    return [{
-        "line": line,
-        "column": column,
-        "error_class": error_class,
-        "message": message,
-    }]
+    return [
+        {
+            "line": line,
+            "column": column,
+            "error_class": error_class,
+            "message": message,
+            "end_line": end_line,
+            "end_column": end_column,
+        }
+    ]
 
 
 if __name__ == "__main__":

--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -85,6 +85,11 @@ def main():
         default=[],
         help="Input parameters for the function, in case the command is eval.",
     )
+    a.add_argument(
+        "--output-format-json",
+        action="store_true",
+        help="Changes the output of the Linter to a json format.",
+    )
     args = a.parse_args()
     command = Command(args.command)
     input_file = args.input_file if args.input_file != "-" else sys.stdin
@@ -137,9 +142,19 @@ def main():
             source_lines = source_code.splitlines()[0]
 
         if command == Command.lint:
-            print(
-                f"{args.input_file}:{start_line+1}:{pos_in_line}: {c.orig_err.__class__.__name__}: {c.orig_err}"
-            )
+            if args.output_format_json:
+                print(
+                    convert_linter_to_json(
+                        start_line,
+                        pos_in_line,
+                        c.orig_err.__class__.__name__,
+                        str(c.orig_err),
+                    )
+                )
+            else:
+                print(
+                    f"{args.input_file}:{start_line+1}:{pos_in_line}: {c.orig_err.__class__.__name__}: {c.orig_err}"
+                )
             return
 
         overwrite_syntaxerror = len("SyntaxError: ") * "\b"
@@ -209,6 +224,15 @@ Note that opshin errors may be overly restrictive as they aim to prevent code wi
             ret = e
         print("------------------")
         print(ret)
+
+
+def convert_linter_to_json(line: int, column: int, error_class: str, message: str):
+    return {
+        "line": line,
+        "column": column,
+        "error_class": error_class,
+        "message": message,
+    }
 
 
 if __name__ == "__main__":

--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -227,12 +227,14 @@ Note that opshin errors may be overly restrictive as they aim to prevent code wi
 
 
 def convert_linter_to_json(line: int, column: int, error_class: str, message: str):
-    return {
+    # output in lists
+    # TODO: possible to detect more than one error at once?
+    return [{
         "line": line,
         "column": column,
         "error_class": error_class,
         "message": message,
-    }
+    }]
 
 
 if __name__ == "__main__":

--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -22,6 +22,7 @@ class Command(enum.Enum):
     parse = "parse"
     eval_uplc = "eval_uplc"
     build = "build"
+    lint = "lint"
 
 
 def plutus_data_from_json(annotation: typing.Type, x: dict):
@@ -134,6 +135,13 @@ def main():
             start_line = 0
             pos_in_line = 0
             source_lines = source_code.splitlines()[0]
+
+        if command == Command.lint:
+            print(
+                f"{args.input_file}:{start_line+1}:{pos_in_line}: {c.orig_err.__class__.__name__}: {c.orig_err}"
+            )
+            return
+
         overwrite_syntaxerror = len("SyntaxError: ") * "\b"
         raise SyntaxError(
             f"""\

--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -231,8 +231,6 @@ def convert_linter_to_json(
     column: int,
     error_class: str,
     message: str,
-    end_line: int | None = None,
-    end_column: int | None = None,
 ):
     # output in lists
     # TODO: possible to detect more than one error at once?
@@ -243,8 +241,6 @@ def convert_linter_to_json(
                 "column": column,
                 "error_class": error_class,
                 "message": message,
-                "end_line": end_line,
-                "end_column": end_column,
             }
         ]
     )


### PR DESCRIPTION
## features
- add a linter built in to the opshin cli kit
- 2 possible outputs
  - standard linter format: 
  `path/to/file.yang:5:19: Linter warning here`
  `path/to/file.yang:6:83: Another warning here `
  - in a json format with the optional flag `--output-format-json`
- very useful for the upcoming [vscode extension](https://github.com/chrissiwaffler/opshin-vscode)
---

## to discuss:
is it possible to output more than 1 syntactic error for the current AST?
-> right now I'm just catching the thrown exception. Since after one exception the AST is no further checked, we don't get more errors
