### PR TITLE
Shebang for distinction of python files #159

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ opshin eval spending examples/smart_contracts/assert_sum.py "{\"int\": 4}" "{\"i
 opshin compile spending examples/smart_contracts/assert_sum.py
 ```
 
+Furthermore, you can add a shebang to the first line of the python file to indicate that it represents an opshin smart contract.
+You can choose from the following options:
+
+- a general shebang: `#!opshin`, which represents `opshin eval any`
+- or a more specific purpose: `#!/usr/bin/env -S opshin eval minting`
+
+By doing so, you can transform your python file to an executable: `chmod +x your_file.py` and execute it with `./your_file.py`, which will run `opshin eval any ./your_file.py` under the hood.
+
+
 ### Deploying
 
 The deploy process generates all artifacts required for usage with common libraries like [pycardano](https://github.com/Python-Cardano/pycardano), [lucid](https://github.com/spacebudz/lucid) and the [cardano-cli](https://github.com/input-output-hk/cardano-node).
@@ -158,6 +167,12 @@ Further, only immutable objects may be generated.
 
 For your program to be accepted, make sure to only make use of language constructs supported by the compiler.
 You will be notified of which constructs are not supported when trying to compile.
+
+You can also make use of the built-in linting command and check it for example with the following command:
+
+```bash
+opshin lint spending examples/smart_contracts/assert_sum.py
+```
 
 ### Name
 

--- a/examples/broken.py
+++ b/examples/broken.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/complex_datum.py
+++ b/examples/complex_datum.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/datum_cast.py
+++ b/examples/datum_cast.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/dict_datum.py
+++ b/examples/dict_datum.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/extract_datum.py
+++ b/examples/extract_datum.py
@@ -1,3 +1,4 @@
+#!opshin
 # This is an example of how to determine the structure of the datum files to use with you opshin custom datums.
 # The JSON file is usually required by third party tools like the cardano-cli
 

--- a/examples/fib_iter.py
+++ b/examples/fib_iter.py
@@ -1,3 +1,6 @@
+#!opshin
+
+
 def validator(n: int) -> int:
     a, b = 0, 1
     for _ in range(n):

--- a/examples/fib_rec.py
+++ b/examples/fib_rec.py
@@ -1,3 +1,6 @@
+#!opshin
+
+
 def fib(n: int) -> int:
     if n == 0:
         res = 0

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -1,2 +1,5 @@
+#!opshin
+
+
 def validator(_: None) -> None:
     print("Hello world!")

--- a/examples/list_comprehensions.py
+++ b/examples/list_comprehensions.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/list_datum.py
+++ b/examples/list_datum.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/mult_for.py
+++ b/examples/mult_for.py
@@ -1,3 +1,6 @@
+#!opshin
+
+
 def validator(a: int, b: int) -> int:
     # trivial implementation of c = a * b
     c = 0

--- a/examples/mult_while.py
+++ b/examples/mult_while.py
@@ -1,3 +1,6 @@
+#!opshin
+
+
 def validator(a: int, b: int) -> int:
     # trivial implementation of c = a * b
     c = 0

--- a/examples/showcase.py
+++ b/examples/showcase.py
@@ -1,3 +1,6 @@
+#!opshin
+
+
 def validator(n: int) -> int:
     # Tuple assignment works
     a, b = 3, n

--- a/examples/smart_contracts/always_true.py
+++ b/examples/smart_contracts/always_true.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/smart_contracts/assert_sum.py
+++ b/examples/smart_contracts/assert_sum.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/smart_contracts/dual_use.py
+++ b/examples/smart_contracts/dual_use.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 """ This contract allows both minting and spending from its address """

--- a/examples/smart_contracts/gift.py
+++ b/examples/smart_contracts/gift.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S opshin eval spending
 from opshin.prelude import *
 
 

--- a/examples/smart_contracts/marketplace.py
+++ b/examples/smart_contracts/marketplace.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S opshin eval spending
 from opshin.prelude import *
 
 

--- a/examples/smart_contracts/parameterized.py
+++ b/examples/smart_contracts/parameterized.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 """ This contract can be parameterized at compile time with a secret value to supply for spending """

--- a/examples/smart_contracts/simple_script.py
+++ b/examples/smart_contracts/simple_script.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/smart_contracts/wrapped_token.py
+++ b/examples/smart_contracts/wrapped_token.py
@@ -1,3 +1,4 @@
+#!opshin
 from opshin.prelude import *
 
 

--- a/examples/sum.py
+++ b/examples/sum.py
@@ -1,2 +1,5 @@
+#!opshin
+
+
 def validator(n: int, m: int) -> int:
     return n + m

--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -138,6 +138,8 @@ def main():
         type=str,
         choices=Command.__members__.keys(),
         help="The command to execute on the input file.",
+        default="eval",
+        nargs="?",
     )
     a.add_argument(
         "purpose",
@@ -146,6 +148,8 @@ def main():
         help="The intended script purpose. Determines the number of on-chain parameters "
         "(spending = 3, minting, rewarding, certifying = 2, any = no checks). "
         "This allows the compiler to check whether the correct amount of parameters was passed during compilation.",
+        default="any",
+        nargs="?",
     )
     a.add_argument(
         "input_file", type=str, help="The input program to parse. Set to - for stdin."


### PR DESCRIPTION
closes https://github.com/OpShin/opshin/issues/159
- running `opshin dual_use.py` will now run `opshin eval any dual_use.py`
- added information about the shebang to the docs

