### PR TITLE
Automatically wrap boolean operations in an implicit cast to bool

### DIFF
--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -5,6 +5,7 @@ from uplc.ast import data_from_cbor
 from .optimize.optimize_const_folding import OptimizeConstantFolding
 from .optimize.optimize_remove_comments import OptimizeRemoveDeadconstants
 from .rewrite.rewrite_augassign import RewriteAugAssign
+from .rewrite.rewrite_cast_condition import RewriteConditions
 from .rewrite.rewrite_forbidden_overwrites import RewriteForbiddenOverwrites
 from .rewrite.rewrite_import import RewriteImport
 from .rewrite.rewrite_import_dataclasses import RewriteImportDataclasses
@@ -1021,6 +1022,7 @@ def compile(
         RewriteForbiddenOverwrites(),
         RewriteImportDataclasses(),
         RewriteInjectBuiltins(),
+        RewriteConditions(),
         # The type inference needs to be run after complex python operations were rewritten
         AggressiveTypeInferencer(),
         # Rewrites that circumvent the type inference or use its results

--- a/opshin/rewrite/rewrite_cast_condition.py
+++ b/opshin/rewrite/rewrite_cast_condition.py
@@ -1,0 +1,32 @@
+from copy import copy
+
+from ast import *
+
+from ..util import CompilingNodeTransformer
+from ..typed_ast import (
+    TypedFunctionDef,
+    FunctionType,
+    NoneInstanceType,
+    TypedConstant,
+    TypedCall,
+    UnitInstanceType,
+)
+
+"""
+Rewrites all occurences of conditions to an implicit cast to bool
+"""
+
+SPECIAL_BOOL = "~bool"
+
+
+class RewriteConditions(CompilingNodeTransformer):
+    step = "Rewriting conditions to bools"
+
+    def visit_Module(self, node: Module) -> Module:
+        node.body.insert(0, Assign([Name(SPECIAL_BOOL, Store())], Name("bool", Load())))
+        return self.generic_visit(node)
+
+    def visit_If(self, node: If) -> If:
+        if_cp = copy(node)
+        if_cp.test = Call(Name(SPECIAL_BOOL, Load()), [node.test], [])
+        return if_cp

--- a/opshin/rewrite/rewrite_cast_condition.py
+++ b/opshin/rewrite/rewrite_cast_condition.py
@@ -30,3 +30,13 @@ class RewriteConditions(CompilingNodeTransformer):
         if_cp = copy(node)
         if_cp.test = Call(Name(SPECIAL_BOOL, Load()), [node.test], [])
         return if_cp
+
+    def visit_IfExp(self, node: IfExp) -> IfExp:
+        if_cp = copy(node)
+        if_cp.test = Call(Name(SPECIAL_BOOL, Load()), [node.test], [])
+        return if_cp
+
+    def visit_While(self, node: While) -> While:
+        while_cp = copy(node)
+        while_cp.test = Call(Name(SPECIAL_BOOL, Load()), [node.test], [])
+        return while_cp

--- a/opshin/rewrite/rewrite_cast_condition.py
+++ b/opshin/rewrite/rewrite_cast_condition.py
@@ -29,14 +29,21 @@ class RewriteConditions(CompilingNodeTransformer):
     def visit_If(self, node: If) -> If:
         if_cp = copy(node)
         if_cp.test = Call(Name(SPECIAL_BOOL, Load()), [node.test], [])
-        return if_cp
+        return self.generic_visit(if_cp)
 
     def visit_IfExp(self, node: IfExp) -> IfExp:
         if_cp = copy(node)
         if_cp.test = Call(Name(SPECIAL_BOOL, Load()), [node.test], [])
-        return if_cp
+        return self.generic_visit(if_cp)
 
     def visit_While(self, node: While) -> While:
         while_cp = copy(node)
         while_cp.test = Call(Name(SPECIAL_BOOL, Load()), [node.test], [])
-        return while_cp
+        return self.generic_visit(while_cp)
+
+    def visit_BoolOp(self, node: BoolOp) -> BoolOp:
+        bo_cp = copy(node)
+        bo_cp.values = [
+            Call(Name(SPECIAL_BOOL, Load()), [self.visit(v)], []) for v in bo_cp.values
+        ]
+        return self.generic_visit(bo_cp)

--- a/opshin/rewrite/rewrite_cast_condition.py
+++ b/opshin/rewrite/rewrite_cast_condition.py
@@ -27,6 +27,13 @@ class RewriteConditions(CompilingNodeTransformer):
         return self.generic_visit(node)
 
     def visit_If(self, node: If) -> If:
+        if (
+            isinstance(node.test, Call)
+            and isinstance(node.test.func, Name)
+            and node.test.func.id == "isinstance"
+        ):
+            # treat isinstance specially
+            return node
         if_cp = copy(node)
         if_cp.test = Call(Name(SPECIAL_BOOL, Load()), [node.test], [])
         return self.generic_visit(if_cp)

--- a/opshin/rewrite/rewrite_cast_condition.py
+++ b/opshin/rewrite/rewrite_cast_condition.py
@@ -47,3 +47,8 @@ class RewriteConditions(CompilingNodeTransformer):
             Call(Name(SPECIAL_BOOL, Load()), [self.visit(v)], []) for v in bo_cp.values
         ]
         return self.generic_visit(bo_cp)
+
+    def visit_Assert(self, node: Assert) -> Assert:
+        assert_cp = copy(node)
+        assert_cp.test = Call(Name(SPECIAL_BOOL, Load()), [node.test], [])
+        return self.generic_visit(assert_cp)

--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -1451,3 +1451,31 @@ def validator(x: int) -> bool:
         code = compiler.compile(ast).compile()
         res = uplc_eval(uplc.Apply(code, uplc.PlutusInteger(x))).value
         self.assertEqual(res, bool(x))
+
+    @hypothesis.given(st.integers())
+    def test_cast_bool_ite_expr(self, x):
+        # note this is a runtime error, just like it would be in python!
+        source_code = """
+def validator(x: int) -> bool:
+    return True if x else False
+"""
+        ast = compiler.parse(source_code)
+        code = compiler.compile(ast).compile()
+        res = uplc_eval(uplc.Apply(code, uplc.PlutusInteger(x))).value
+        self.assertEqual(res, bool(x))
+
+    @hypothesis.given(st.integers())
+    def test_cast_bool_while(self, x):
+        # note this is a runtime error, just like it would be in python!
+        source_code = """
+def validator(x: int) -> bool:
+    res = False
+    while x:
+        res = True
+        x = 0
+    return res
+"""
+        ast = compiler.parse(source_code)
+        code = compiler.compile(ast).compile()
+        res = uplc_eval(uplc.Apply(code, uplc.PlutusInteger(x))).value
+        self.assertEqual(res, bool(x))

--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -1479,3 +1479,15 @@ def validator(x: int) -> bool:
         code = compiler.compile(ast).compile()
         res = uplc_eval(uplc.Apply(code, uplc.PlutusInteger(x))).value
         self.assertEqual(res, bool(x))
+
+    @hypothesis.given(st.integers())
+    def test_cast_bool_boolops(self, x):
+        # note this is a runtime error, just like it would be in python!
+        source_code = """
+def validator(x: int) -> bool:
+    return x and x or (x or x)
+"""
+        ast = compiler.parse(source_code)
+        code = compiler.compile(ast).compile()
+        res = uplc_eval(uplc.Apply(code, uplc.PlutusInteger(x))).value
+        self.assertEqual(res, bool(x and x or (x or x)))

--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -1435,3 +1435,19 @@ def validator(x: bytes, y: bytes) -> bytes:
             )
         ).value
         self.assertEqual(res, x + y)
+
+    @hypothesis.given(st.integers())
+    def test_cast_bool_ite(self, x):
+        # note this is a runtime error, just like it would be in python!
+        source_code = """
+def validator(x: int) -> bool:
+    if x:
+        res = True
+    else:
+        res = False
+    return res
+"""
+        ast = compiler.parse(source_code)
+        code = compiler.compile(ast).compile()
+        res = uplc_eval(uplc.Apply(code, uplc.PlutusInteger(x))).value
+        self.assertEqual(res, bool(x))

--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -1491,3 +1491,19 @@ def validator(x: int) -> bool:
         code = compiler.compile(ast).compile()
         res = uplc_eval(uplc.Apply(code, uplc.PlutusInteger(x))).value
         self.assertEqual(res, bool(x and x or (x or x)))
+
+    @hypothesis.given(st.integers())
+    def test_cast_bool_ite(self, x):
+        # note this is a runtime error, just like it would be in python!
+        source_code = """
+def validator(x: int) -> None:
+    assert x
+"""
+        ast = compiler.parse(source_code)
+        code = compiler.compile(ast).compile()
+        try:
+            uplc_eval(uplc.Apply(code, uplc.PlutusInteger(x)))
+            res = True
+        except Exception:
+            res = False
+        self.assertEqual(res, bool(x))


### PR DESCRIPTION
Now you can write whatever statement in places where boolean expressions are definitely expected (i.e. `if [] and 0: ...`)
and they are automatically typecast to `bool`