### PR TITLE
Allow accessing attributes with shared name but differing position

### DIFF
--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -688,7 +688,7 @@ def validator(x: Union[A, B]) -> Union[SomeOutputDatumHash, SomeOutputDatum]:
 
         res = uplc_eval(
             uplc.Apply(code, uplc.data_from_cbor(x.to_cbor())),
-        ).value
+        )
         self.assertEqual(res, uplc.data_from_cbor(x.foo.to_cbor()))
 
     @unittest.expectedFailure

--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -692,6 +692,7 @@ def validator(x: Union[A, B]) -> Union[SomeOutputDatumHash, SomeOutputDatum]:
         self.assertEqual(res, uplc.data_from_cbor(x.foo.to_cbor()))
 
     @hypothesis.given(some_output, st.sampled_from([1, 2, 3]))
+    @hypothesis.settings(deadline=None)
     def test_union_type_attr_access_all_records_diff_pos(self, x, y):
         source_code = """
 from opshin.prelude import *

--- a/opshin/types.py
+++ b/opshin/types.py
@@ -463,7 +463,9 @@ class UnionType(ClassType):
             return IntegerInstanceType
         # need to have a common field with the same name
         if all(attr in (n for n, t in x.record.fields) for x in self.typs):
-            attr_types = [t for x in self.typs for n, t in x.record.fields if n == attr]
+            attr_types = set(
+                t for x in self.typs for n, t in x.record.fields if n == attr
+            )
             for at in attr_types:
                 # return the maximum element if there is one
                 if all(at >= at2 for at2 in attr_types):
@@ -520,7 +522,7 @@ class UnionType(ClassType):
                 constr_check = plt.EqualsInteger(
                     plt.Var("constr"), plt.Integer(constrs[0])
                 )
-                for constr in constrs:
+                for constr in constrs[1:]:
                     constr_check = plt.Or(
                         plt.EqualsInteger(plt.Var("constr"), plt.Integer(constr)),
                         constr_check,

--- a/opshin/types.py
+++ b/opshin/types.py
@@ -460,13 +460,11 @@ class UnionType(ClassType):
     def attribute_type(self, attr) -> "Type":
         if attr == "CONSTR_ID":
             return IntegerInstanceType
-        # iterate through all names/types of the unioned records by position
-        for attr_names, attr_types in map(
-            lambda x: zip(*x), zip(*(t.record.fields for t in self.typs))
-        ):
-            # need to have a common field with the same name, in the same position!
-            if any(attr_name != attr for attr_name in attr_names):
-                continue
+        # need to have a common field with the same name
+        if all(attr in (f[0] for f in x.record.fields) for x in self.typs):
+            attr_types = (
+                f[1] for x in self.typs for f in x.record.fields if f[0] == attr
+            )
             for at in attr_types:
                 # return the maximum element if there is one
                 if all(at >= at2 for at2 in attr_types):

--- a/opshin/types.py
+++ b/opshin/types.py
@@ -462,7 +462,7 @@ class UnionType(ClassType):
             return IntegerInstanceType
         # need to have a common field with the same name
         if all(attr in (n for n, t in x.record.fields) for x in self.typs):
-            attr_types = (t for x in self.typs for n, t in x.record.fields if n == attr)
+            attr_types = [t for x in self.typs for n, t in x.record.fields if n == attr]
             for at in attr_types:
                 # return the maximum element if there is one
                 if all(at >= at2 for at2 in attr_types):
@@ -498,11 +498,11 @@ class UnionType(ClassType):
             pos_constrs = [
                 (i, x.record.constructor)
                 for x in self.typs
-                for i, (n, t) in x.record.fields
+                for i, (n, t) in enumerate(x.record.fields)
                 if n == attr
             ]
             # access to normal fields
-            pos_decisor = plt.Error()
+            pos_decisor = plt.TraceError("Invalid constructor")
             for pos, constr in pos_constrs:
                 pos_decisor = plt.Ite(
                     plt.EqualsInteger(plt.Var("constr"), plt.Integer(constr)),


### PR DESCRIPTION
So far, attributes with same name *and* same position in the PlutusData definition could be accessed among elements in a Union type. With this update, the same name is sufficient by deciding the correct position of the attribute at runtime. It contains an optimization where this decision is not needed if all elements store the attribute at the same position.