### PR TITLE
Fix an error where UnionType was always allowed to be compared with List[X]

### DIFF
--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -2298,3 +2298,19 @@ def validator(x: int) -> str:
         code = compiler.compile(ast).compile()
         res = uplc_eval(uplc.Apply(code, uplc.PlutusInteger(1)))
         self.assertEqual(res.value, b"hello")
+
+    @unittest.expectedFailure
+    def test_in_list(self):
+        source_code = """
+from opshin.prelude import *
+
+def validator(
+    d: Nothing,
+    r: Nothing,
+    context: ScriptContext,
+):
+    assert context.purpose in context.tx_info.signatories
+"""
+        ast = compiler.parse(source_code)
+        code = compiler.compile(ast)
+        code = code.compile()

--- a/opshin/types.py
+++ b/opshin/types.py
@@ -579,7 +579,7 @@ class UnionType(ClassType):
         if (
             isinstance(o, ListType)
             and isinstance(o.typ, InstanceType)
-            and (o.typ.typ >= t or t >= o.typ.typ for t in self.typs)
+            and any(o.typ.typ >= t or t >= o.typ.typ for t in self.typs)
         ):
             if isinstance(op, In):
                 return plt.Lambda(


### PR DESCRIPTION
This is a non-critical bug since it only allowed compilation of commands that would always fail (leading to preservation of user funds)