### PR TITLE
Fix usage of FrozenList/frozenlist

### DIFF
--- a/opshin/types.py
+++ b/opshin/types.py
@@ -1928,8 +1928,8 @@ def empty_list(p: Type):
             uplc.BuiltinList(
                 [],
                 uplc.BuiltinPair(
-                    uplc.PlutusConstr(0, FrozenList([])),
-                    uplc.PlutusConstr(0, FrozenList([])),
+                    uplc.PlutusConstr(0, frozenlist([])),
+                    uplc.PlutusConstr(0, frozenlist([])),
                 ),
             )
         )


### PR DESCRIPTION
This is a non-critical bug because the usage of non-imported names would have led to a failure of the compilation and not produced any buggy contract code.