### PR TITLE
Feat/force nothing three params

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,7 +126,8 @@ This has a number of benefits:
 This comes at the cost of an ugly hack.
 Generally, all validator functions `v` are wrapped in a short script that takes two arguments `a0` and `a1`.
 It checks whether `a1` is a ScriptContext by checking if it is PlutusData and has constructor id `0`.
-If so, `v((), a0, a1)` is executed and returned.
+If so, `v({6:[]}, a0, a1)` is executed and returned,
+where `{6:[]}` represents an object of type `Nothing` as defined in the prelude.
 If not, `v(a0, a1)` is executed (the first two arguments being bound to the function)
 and returned, expecting as only argument the remaining script context.
 

--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -125,6 +125,16 @@ def check_params(
     assert (
         ret_type is None or ret_type == prelude.Anything
     ), f"Expected contract to return None, but returns {ret_type}"
+    if force_three_params:
+        datum_type = validator_args[0]
+        assert (
+            (
+                typing.get_origin(datum_type) == typing.Union
+                and prelude.Nothing in typing.get_args(datum_type)
+            )
+            or datum_type == prelude.Anything
+            or datum_type == prelude.Nothing
+        ), f"Expected contract to accept Nothing or Anything as datum since it forces three parameters, but got {datum_type}"
 
     num_onchain_params = 3 if purpose == Purpose.spending or force_three_params else 2
     onchain_params = validator_args[-1 - num_onchain_params : -1]

--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -174,8 +174,13 @@ def wrap_validator_double_function(x: plt.AST, pass_through: int = 0):
                     plt.Bool(False),
                     plt.Bool(False),
                 ),
-                # call the validator with a0, a1, and plug in Unit for data
-                plt.Apply(plt.Var("p"), plt.Unit(), plt.Var("a0"), plt.Var("a1")),
+                # call the validator with a0, a1, and plug in "Nothing" for data
+                plt.Apply(
+                    plt.Var("p"),
+                    plt.UPLCConstant(uplc.PlutusConstr(6, [])),
+                    plt.Var("a0"),
+                    plt.Var("a1"),
+                ),
                 # else call the validator with a0, a1 and return (now partially bound)
                 plt.Apply(plt.Var("p"), plt.Var("a0"), plt.Var("a1")),
             ),

--- a/opshin/ledger/api_v2.py
+++ b/opshin/ledger/api_v2.py
@@ -21,18 +21,6 @@ class TxId(PlutusData):
 
 
 @dataclass(unsafe_hash=True)
-class Nothing(PlutusData):
-    """
-    Nothing, can be used to signify non-importance of a parameter to a function
-
-    Example value: Nothing()
-    """
-
-    # The maximimum constructor ID for simple cbor types, chosen to minimize probability of collision while keeping the corresponding cbor small
-    CONSTR_ID = 6
-
-
-@dataclass(unsafe_hash=True)
 class TrueData(PlutusData):
     """
     A Datum that represents True in Haskell implementations.

--- a/opshin/prelude.py
+++ b/opshin/prelude.py
@@ -3,6 +3,18 @@ from hashlib import sha256, sha3_256, blake2b
 
 
 @dataclass(unsafe_hash=True)
+class Nothing(PlutusData):
+    """
+    Nothing, can be used to signify non-importance of a parameter to a function
+
+    Example value: Nothing()
+    """
+
+    # The maximimum constructor ID for simple cbor types, chosen to minimize probability of collision while keeping the corresponding cbor small
+    CONSTR_ID = 6
+
+
+@dataclass(unsafe_hash=True)
 class Token(PlutusData):
     """
     A token, represented by policy id and token name


### PR DESCRIPTION
This forces users to allow for `Nothing` to appear as a datum when forcing three parameters for the script. This helps representing the fact that for non-spending purposes, the datum field is omitted.