### PR TITLE
Fix/attribute has no lineno

### DIFF
--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -254,6 +254,7 @@ def perform_command(args):
             constant_folding=constant_folding,
             # do not remove dead code when compiling a library - none of the code will be used
             remove_dead_code=purpose != Purpose.lib,
+            allow_isinstance_anything=args.allow_isinstance_anything,
         )
     except CompilerError as c:
         # Generate nice error message from compiler error
@@ -387,6 +388,11 @@ def parse_args():
         "--cf",
         action="store_true",
         help="Enables experimental constant folding, including propagation and code execution.",
+    )
+    a.add_argument(
+        "--allow-isinstance-anything",
+        action="store_true",
+        help="Enables the use of isinstance(x, D) in the contract where x is of type Anything. This is not recommended as it only checks the constructor id and not the actual type of the data.",
     )
     a.add_argument(
         "args",

--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -1012,35 +1012,6 @@ class UPLCCompiler(CompilingNodeTransformer):
         raise NotImplementedError(f"Can not compile {node}")
 
 
-def custom_fix_missing_locations(node):
-    """
-    Works like ast.fix_missing_location but forces it onto everything
-    """
-
-    def _fix(node, lineno, col_offset, end_lineno, end_col_offset):
-        if not hasattr(node, "lineno"):
-            node.lineno = lineno
-        else:
-            lineno = node.lineno
-        if getattr(node, "end_lineno", None) is None:
-            node.end_lineno = end_lineno
-        else:
-            end_lineno = node.end_lineno
-        if not hasattr(node, "col_offset"):
-            node.col_offset = col_offset
-        else:
-            col_offset = node.col_offset
-        if getattr(node, "end_col_offset", None) is None:
-            node.end_col_offset = end_col_offset
-        else:
-            end_col_offset = node.end_col_offset
-        for child in iter_child_nodes(node):
-            _fix(child, lineno, col_offset, end_lineno, end_col_offset)
-
-    _fix(node, 1, 0, 1, 0)
-    return node
-
-
 def compile(
     prog: AST,
     filename=None,

--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -1019,6 +1019,7 @@ def compile(
     remove_dead_code=True,
     constant_folding=False,
     validator_function_name="validator",
+    allow_isinstance_anything=False,
 ):
     compile_pipeline = [
         # Important to call this one first - it imports all further files
@@ -1037,7 +1038,7 @@ def compile(
         RewriteInjectBuiltins(),
         RewriteConditions(),
         # The type inference needs to be run after complex python operations were rewritten
-        AggressiveTypeInferencer(),
+        AggressiveTypeInferencer(allow_isinstance_anything),
         # Rewrites that circumvent the type inference or use its results
         RewriteImportUPLCBuiltins(),
         RewriteInjectBuiltinsConstr(),

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -775,6 +775,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
             )
             ntc.typ = BoolInstanceType
             ntc.typechecks = TypeCheckVisitor().visit(tc)
+            custom_fix_missing_locations(ntc, node)
             return ntc
         tc.func = self.visit(node.func)
         # might be a class

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -181,6 +181,9 @@ class TypeCheckVisitor(TypedNodeVisitor):
     is True/False respectively
     """
 
+    def __init__(self, allow_isinstance_anything=False):
+        self.allow_isinstance_anything = allow_isinstance_anything
+
     def generic_visit(self, node: AST) -> TypeMapPair:
         return getattr(node, "typechecks", ({}, {}))
 
@@ -197,23 +200,25 @@ class TypeCheckVisitor(TypedNodeVisitor):
             node.args[1], Name
         ), "Target 1 of an isinstance cast must be a class name"
         target_class: RecordType = node.args[1].typ
-        target_inst = node.args[0]
-        target_inst_class = target_inst.typ
+        inst = node.args[0]
+        inst_class = inst.typ
         assert isinstance(
-            target_inst_class, InstanceType
+            inst_class, InstanceType
         ), "Can only cast instances, not classes"
         assert isinstance(target_class, RecordType), "Can only cast to PlutusData"
-        if isinstance(target_inst_class.typ, UnionType):
+        if isinstance(inst_class.typ, UnionType):
             assert (
-                target_class in target_inst_class.typ.typs
+                target_class in inst_class.typ.typs
             ), f"Trying to cast an instance of Union type to non-instance of union type"
             union_without_target_class = union_types(
-                *(x for x in target_inst_class.typ.typs if x != target_class)
+                *(x for x in inst_class.typ.typs if x != target_class)
             )
+        elif isinstance(inst_class.typ, AnyType) and self.allow_isinstance_anything:
+            union_without_target_class = AnyType()
         else:
             assert (
-                target_inst_class.typ == target_class
-            ), "Can only cast instances of Union types of PlutusData or cast the same class"
+                inst_class.typ == target_class
+            ), "Can only cast instances of Union types of PlutusData or cast the same class. If you know what you are doing, enable the flag '--allow-isinstance-anything'"
             union_without_target_class = target_class
         varname = node.args[0].id
         return ({varname: target_class}, {varname: union_without_target_class})
@@ -387,7 +392,9 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
             stmts.append(stmt)
             # if an assert is amng the statements apply the isinstance cast
             if isinstance(stmt, Assert):
-                typchecks, _ = TypeCheckVisitor().visit(stmt.test)
+                typchecks, _ = TypeCheckVisitor(self.allow_isinstance_anything).visit(
+                    stmt.test
+                )
                 # for the time after this assert, the variable has the specialized type
                 prevtyps.update(self.implement_typechecks(typchecks))
         self.implement_typechecks(prevtyps)
@@ -476,7 +483,9 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
         assert (
             typed_if.test.typ == BoolInstanceType
         ), "Branching condition must have boolean type"
-        typchecks, inv_typchecks = TypeCheckVisitor().visit(typed_if.test)
+        typchecks, inv_typchecks = TypeCheckVisitor(
+            self.allow_isinstance_anything
+        ).visit(typed_if.test)
         # for the time of the branch, these types are cast
         initial_scope = copy(self.scopes[-1])
         self.implement_typechecks(typchecks)
@@ -499,7 +508,9 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
         assert (
             typed_while.test.typ == BoolInstanceType
         ), "Branching condition must have boolean type"
-        typchecks, inv_typchecks = TypeCheckVisitor().visit(typed_while.test)
+        typchecks, inv_typchecks = TypeCheckVisitor(
+            self.allow_isinstance_anything
+        ).visit(typed_while.test)
         # for the time of the branch, these types are cast
         initial_scope = copy(self.scopes[-1])
         self.implement_typechecks(typchecks)
@@ -648,7 +659,9 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
             prevtyps = {}
             for e in node.values:
                 values.append(self.visit(e))
-                typchecks, _ = TypeCheckVisitor().visit(values[-1])
+                typchecks, _ = TypeCheckVisitor(self.allow_isinstance_anything).visit(
+                    values[-1]
+                )
                 # for the time after the shortcut and the variable type to the specialized type
                 prevtyps.update(self.implement_typechecks(typchecks))
             self.implement_typechecks(prevtyps)
@@ -658,7 +671,9 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
             prevtyps = {}
             for e in node.values:
                 values.append(self.visit(e))
-                _, inv_typechecks = TypeCheckVisitor().visit(values[-1])
+                _, inv_typechecks = TypeCheckVisitor(
+                    self.allow_isinstance_anything
+                ).visit(values[-1])
                 # for the time after the shortcut or the variable type is *not* the specialized type
                 prevtyps.update(self.implement_typechecks(inv_typechecks))
             self.implement_typechecks(prevtyps)
@@ -786,7 +801,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
             custom_fix_missing_locations(ntc, node)
             ntc = self.visit(ntc)
             ntc.typ = BoolInstanceType
-            ntc.typechecks = TypeCheckVisitor().visit(tc)
+            ntc.typechecks = TypeCheckVisitor(self.allow_isinstance_anything).visit(tc)
             return ntc
         tc.func = self.visit(node.func)
         # might be a class
@@ -856,7 +871,9 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
         node_cp = copy(node)
         node_cp.test = self.visit(node.test)
         assert node_cp.test.typ == BoolInstanceType, "Comparison must have type boolean"
-        typchecks, inv_typchecks = TypeCheckVisitor().visit(node_cp.test)
+        typchecks, inv_typchecks = TypeCheckVisitor(
+            self.allow_isinstance_anything
+        ).visit(node_cp.test)
         prevtyps = self.implement_typechecks(typchecks)
         node_cp.body = self.visit(node.body)
         self.implement_typechecks(prevtyps)

--- a/opshin/types.py
+++ b/opshin/types.py
@@ -78,6 +78,22 @@ class ClassType(Type):
 class AnyType(ClassType):
     """The top element in the partial order on types (excluding FunctionTypes, which do not compare to anything)"""
 
+    def attribute_type(self, attr: str) -> Type:
+        """The types of the named attributes of this class"""
+        if attr == "CONSTR_ID":
+            return IntegerInstanceType
+        return super().attribute_type(attr)
+
+    def attribute(self, attr: str) -> plt.AST:
+        """The attributes of this class. Need to be a lambda that expects as first argument the object itself"""
+        if attr == "CONSTR_ID":
+            # access to constructor
+            return plt.Lambda(
+                ["self"],
+                plt.Constructor(plt.Var("self")),
+            )
+        return super().attribute(attr)
+
     def __ge__(self, other):
         return (
             isinstance(other, ClassType)

--- a/opshin/types.py
+++ b/opshin/types.py
@@ -23,12 +23,14 @@ class Type:
 
     def constr(self) -> plt.AST:
         """The constructor for this class"""
-        raise NotImplementedError(f"Constructor of {self.__class__} not implemented")
+        raise NotImplementedError(
+            f"Constructor of {type(self).__name__} not implemented"
+        )
 
     def attribute_type(self, attr) -> "Type":
         """The types of the named attributes of this class"""
         raise TypeInferenceError(
-            f"Object of type {self.__class__} does not have attribute {attr}"
+            f"Object of type {type(self).__name__} does not have attribute {attr}"
         )
 
     def attribute(self, attr) -> plt.AST:


### PR DESCRIPTION
This fixes #242 and https://github.com/OpShin/opshin/issues/70#issuecomment-1459741269 (note that checking whether Anything is an integer/string/bytes/bool is still disallowed)

Specifically it
- fixes adding missing location annotations for isinstance calls
- allows isinstance checks/casts for Anything/Datum type objects with the flag `--allow-isinstance-anything`