### PR TITLE
Feat/copy only attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
 - coverage run -a --source=opshin -m opshin compile lib opshin/prelude.py
 # build the libraries
 - >
-  for i in $(find opshin/std opshin/ledger -type f -name "*.py"); do
+  for i in $(find opshin/std opshin/ledger -type f -name "*.py" ! -name "*integrity.py"); do
     echo "$i"
     coverage run -a --source=opshin -m opshin compile lib "$i" > /dev/null || exit
   done

--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -11,6 +11,7 @@ from .rewrite.rewrite_forbidden_overwrites import RewriteForbiddenOverwrites
 from .rewrite.rewrite_import import RewriteImport
 from .rewrite.rewrite_import_dataclasses import RewriteImportDataclasses
 from .rewrite.rewrite_import_hashlib import RewriteImportHashlib
+from .rewrite.rewrite_import_integrity_check import RewriteImportIntegrityCheck
 from .rewrite.rewrite_import_plutusdata import RewriteImportPlutusData
 from .rewrite.rewrite_import_typing import RewriteImportTyping
 from .rewrite.rewrite_import_uplc_builtins import RewriteImportUPLCBuiltins
@@ -1058,6 +1059,7 @@ def compile(
         RewriteAugAssign(),
         RewriteComparisonChaining(),
         RewriteTupleAssign(),
+        RewriteImportIntegrityCheck(),
         RewriteImportPlutusData(),
         RewriteImportHashlib(),
         RewriteImportTyping(),

--- a/opshin/rewrite/rewrite_import.py
+++ b/opshin/rewrite/rewrite_import.py
@@ -67,6 +67,7 @@ class RewriteImport(CompilingNodeTransformer):
             "dataclasses",
             "hashlib",
             "opshin.bridge",
+            "opshin.std.integrity",
         ]:
             return node
         assert (

--- a/opshin/rewrite/rewrite_import_integrity_check.py
+++ b/opshin/rewrite/rewrite_import_integrity_check.py
@@ -53,5 +53,7 @@ class RewriteImportIntegrityCheck(CompilingNodeTransformer):
                 n.name == FunctionName
             ), "Imports something other from the integrity check than the integrity check builtin"
             renamed = n.asname if n.asname is not None else n.name
-            INITIAL_SCOPE[renamed] = IntegrityCheckImpl()
+            INITIAL_SCOPE[renamed] = InstanceType(
+                PolymorphicFunctionType(IntegrityCheckImpl())
+            )
         return None

--- a/opshin/rewrite/rewrite_import_integrity_check.py
+++ b/opshin/rewrite/rewrite_import_integrity_check.py
@@ -1,0 +1,57 @@
+import re
+from copy import copy
+from typing import Optional
+from enum import Enum
+
+from ..type_inference import INITIAL_SCOPE
+from ..util import CompilingNodeTransformer
+from ..typed_ast import *
+
+"""
+Injects the integrity checker function if it is imported
+"""
+
+FunctionName = "check_integrity"
+
+
+class IntegrityCheckImpl(PolymorphicFunction):
+    def type_from_args(self, args: typing.List[Type]) -> FunctionType:
+        assert (
+            len(args) == 1
+        ), f"'integrity_check' takes only one argument, but {len(args)} were given"
+        typ = args[0]
+        assert isinstance(typ, InstanceType), "Can only check integrity of instances"
+        assert any(
+            isinstance(typ.typ, t) for t in (RecordType, UnionType)
+        ), "Can only check integrity of PlutusData and Union types"
+        return FunctionType(args, NoneInstanceType)
+
+    def impl_from_args(self, args: typing.List[Type]) -> plt.AST:
+        arg = args[0]
+        assert isinstance(arg, InstanceType), "Can only check integrity of instances"
+        return plt.Lambda(
+            ["x", "_"],
+            plt.Ite(
+                plt.EqualsData(
+                    plt.Var("x"),
+                    plt.Apply(arg.typ.copy_only_attributes(), plt.Var("x")),
+                ),
+                plt.Unit(),
+                plt.TraceError("ValueError: datum integrity check failed"),
+            ),
+        )
+
+
+class RewriteImportIntegrityCheck(CompilingNodeTransformer):
+    step = "Resolving imports and usage of integrity check"
+
+    def visit_ImportFrom(self, node: ImportFrom) -> Optional[AST]:
+        if node.module != "opshin.std.integrity":
+            return node
+        for n in node.names:
+            assert (
+                n.name == FunctionName
+            ), "Imports something other from the integrity check than the integrity check builtin"
+            renamed = n.asname if n.asname is not None else n.name
+            INITIAL_SCOPE[renamed] = IntegrityCheckImpl()
+        return None

--- a/opshin/std/integrity.py
+++ b/opshin/std/integrity.py
@@ -1,0 +1,17 @@
+"""
+A special libary that gives access to a function that checks the integrity of PlutusDatum objects.
+"""
+from pycardano import PlutusData
+
+
+def integrity_check(x: PlutusData) -> None:
+    """
+    Checks the integrity of a PlutusDatum object.
+    In particular, it takes an object of any type and checks that
+    - the constructor id matches the id defined in the type
+    - the fields specified in the type are present
+    - no additional fields are present
+
+    This has no equivalent in Python.
+    """
+    pass

--- a/opshin/std/integrity.py
+++ b/opshin/std/integrity.py
@@ -4,7 +4,7 @@ A special libary that gives access to a function that checks the integrity of Pl
 from pycardano import PlutusData
 
 
-def integrity_check(x: PlutusData) -> None:
+def check_integrity(x: PlutusData) -> None:
     """
     Checks the integrity of a PlutusDatum object.
     In particular, it takes an object of any type and checks that

--- a/opshin/tests/test_std/test_integrity.py
+++ b/opshin/tests/test_std/test_integrity.py
@@ -1,0 +1,39 @@
+from parameterized import parameterized
+
+from uplc import ast as uplc, eval as uplc_eval
+from ... import compiler
+
+
+@parameterized.expand(
+    [
+        [[0, 1]],
+        [[0]],
+        [[0, 1, 2]],
+    ]
+)
+def test_integrity_check(xs):
+    source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+from opshin.std.integrity import check_integrity
+
+@dataclass()
+class B(PlutusData):
+    CONSTR_ID = 1
+    foobar: int
+    bar: int
+
+def validator(x: B) -> None:
+    check_integrity(x)
+"""
+    ast = compiler.parse(source_code)
+    code = compiler.compile(ast).compile()
+    code = uplc.Apply(code, uplc.PlutusConstr(1, [uplc.PlutusInteger(x) for x in xs]))
+    try:
+        uplc_eval(code)
+    except:
+        res = False
+    else:
+        res = True
+    assert res == (len(xs) == 2)

--- a/opshin/types.py
+++ b/opshin/types.py
@@ -464,7 +464,10 @@ class RecordType(ClassType):
         copied_attributes = plt.EmptyDataList()
         for attr_name, attr_type in reversed(self.record.fields):
             copied_attributes = plt.Let(
-                [("f", plt.HeadList("fs")), ("fs", plt.TailList("fs"))],
+                [
+                    ("f", plt.HeadList(plt.Var("fs"))),
+                    ("fs", plt.TailList(plt.Var("fs"))),
+                ],
                 plt.MkCons(
                     plt.Apply(attr_type.copy_only_attributes(), plt.Var("f")),
                     copied_attributes,


### PR DESCRIPTION
This tackles #241 

The provided update provides the user with a function `check_integrity` which checks that

- the constructor id matches
- the fields specified in the type of the object are present
- no additional fields are present