### PR TITLE
Allow ByteString and bytearray synonyms for bytes as type annotations

### DIFF
--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -2039,3 +2039,21 @@ def validator(
         # would fail because Address is assigned multiple times and then not constant folded
         # TODO find a better way
         builder._compile(source_code, constant_folding=True)
+
+    def test_bytearray_alternative(self):
+        source_code = """
+def validator(
+    d: bytearray,
+) -> bytes:
+    return d
+"""
+        eval_uplc(source_code, bytearray(b"hello"))
+
+    def test_ByteString_alternative(self):
+        source_code = """
+def validator(
+    d: ByteString,
+) -> bytes:
+    return d
+"""
+        eval_uplc(source_code, bytearray(b"hello"))

--- a/opshin/types.py
+++ b/opshin/types.py
@@ -1774,6 +1774,8 @@ ATOMIC_TYPES = {
     int.__name__: IntegerType(),
     str.__name__: StringType(),
     bytes.__name__: ByteStringType(),
+    "ByteString": ByteStringType(),
+    bytearray.__name__: ByteStringType(),
     type(None).__name__: UnitType(),
     bool.__name__: BoolType(),
 }


### PR DESCRIPTION
This tackles #276 (supposedly)