### PR TITLE
Inline constant expressions that are only read once

### DIFF
--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -3,6 +3,7 @@ from pycardano import PlutusData
 
 from uplc.ast import data_from_cbor
 from .optimize.optimize_const_folding import OptimizeConstantFolding
+from .optimize.optimize_inline_constvars import OptimizeInlineConstvars
 from .optimize.optimize_remove_comments import OptimizeRemoveDeadconstants
 from .rewrite.rewrite_augassign import RewriteAugAssign
 from .rewrite.rewrite_cast_condition import RewriteConditions
@@ -1053,6 +1054,7 @@ def compile(
         OptimizeVarlen(),
         OptimizeRemoveDeadconstants(),
         OptimizeRemovePass(),
+        OptimizeInlineConstvars(),
     ]
     for s in compile_pipeline:
         prog = s.visit(prog)

--- a/opshin/optimize/optimize_const_folding.py
+++ b/opshin/optimize/optimize_const_folding.py
@@ -1,17 +1,21 @@
 import typing
-from collections import defaultdict
 import logging
 
 from ast import *
 
 from pycardano import PlutusData
 
+
 try:
     unparse
 except NameError:
     from astunparse import unparse
 
-from ..util import CompilingNodeTransformer, CompilingNodeVisitor
+from ..util import (
+    CompilingNodeTransformer,
+    ShallowNameDefCollector,
+    DefinedTimesVisitor,
+)
 from ..type_inference import INITIAL_SCOPE
 
 """
@@ -92,79 +96,6 @@ SAFE_GLOBALS_LIST = [
     zip,
 ]
 SAFE_GLOBALS = {x.__name__: x for x in SAFE_GLOBALS_LIST}
-
-
-class ShallowNameDefCollector(CompilingNodeVisitor):
-    step = "Collecting occuring variable names"
-
-    def __init__(self):
-        self.vars = set()
-
-    def visit_Name(self, node: Name) -> None:
-        if isinstance(node.ctx, Store):
-            self.vars.add(node.id)
-
-    def visit_ClassDef(self, node: ClassDef):
-        self.vars.add(node.name)
-        # ignore the content (i.e. attribute names) of class definitions
-
-    def visit_FunctionDef(self, node: FunctionDef):
-        self.vars.add(node.name)
-        # ignore the recursive stuff
-
-
-class DefinedTimesVisitor(CompilingNodeVisitor):
-    step = "Collecting how often variables are written"
-
-    def __init__(self):
-        self.vars = defaultdict(int)
-
-    def visit_For(self, node: For) -> None:
-        # visit twice to have all names bumped to min 2 assignments
-        self.generic_visit(node)
-        self.generic_visit(node)
-        return
-        # TODO future items: use this together with guaranteed available
-        # visit twice to have this name bumped to min 2 assignments
-        self.visit(node.target)
-        # visit the whole function
-        self.generic_visit(node)
-
-    def visit_While(self, node: While) -> None:
-        # visit twice to have all names bumped to min 2 assignments
-        self.generic_visit(node)
-        self.generic_visit(node)
-        return
-        # TODO future items: use this together with guaranteed available
-
-    def visit_If(self, node: If) -> None:
-        # TODO future items: use this together with guaranteed available
-        # visit twice to have all names bumped to min 2 assignments
-        self.generic_visit(node)
-        self.generic_visit(node)
-
-    def visit_Name(self, node: Name) -> None:
-        if isinstance(node.ctx, Store):
-            self.vars[node.id] += 1
-
-    def visit_ClassDef(self, node: ClassDef):
-        self.vars[node.name] += 1
-        # ignore the content (i.e. attribute names) of class definitions
-
-    def visit_FunctionDef(self, node: FunctionDef):
-        self.vars[node.name] += 1
-        # visit arguments twice, they are generally assigned more than once
-        for arg in node.args.args:
-            self.vars[arg.arg] += 2
-        self.generic_visit(node)
-
-    def visit_Import(self, node: Import):
-        for n in node.names:
-            self.vars[n] += 1
-
-    def visit_ImportFrom(self, node: ImportFrom):
-        for n in node.names:
-            self.vars[n] += 1
 
 
 class OptimizeConstantFolding(CompilingNodeTransformer):

--- a/opshin/optimize/optimize_inline_constvars.py
+++ b/opshin/optimize/optimize_inline_constvars.py
@@ -1,0 +1,66 @@
+from typing import Optional, Union
+
+from ast import *
+from copy import copy
+from collections import defaultdict
+
+from ..util import CompilingNodeVisitor, CompilingNodeTransformer, DefinedTimesVisitor
+from ..type_inference import INITIAL_SCOPE
+from ..typed_ast import TypedAnnAssign
+
+"""
+Removes assignments to variables that are never read
+"""
+
+
+class VariableValueCollector(CompilingNodeVisitor):
+    values = defaultdict(list)
+
+    def __init__(self, constants):
+        self.constants = constants
+
+    def visit_Assign(self, node: Assign) -> None:
+        assert len(node.targets) == 1
+        t = node.targets[0]
+        if isinstance(t, Name) and t.id in self.constants:
+            self.values[t.id].append(node.value)
+            return None
+        return self.generic_visit(node)
+
+
+class OptimizeInlineConstvars(CompilingNodeTransformer):
+    step = "Inline variables that are constant (i.e. written only once)"
+
+    constants = set()
+    constant_value = {}
+
+    def visit_Module(self, node: Module) -> Module:
+        # repeat until no more change due to removal
+        # i.e. b = a; c = b needs 2 passes to remove c and b
+        node_cp = copy(node)
+        # collect all variable names
+        constant_collector = DefinedTimesVisitor()
+        constant_collector.visit(node)
+        constants = constant_collector.vars
+        # if it is only assigned exactly once, it must be a constant (due to immutability)
+        self.constants = {c for c, i in constants.items() if i == 1}
+        constant_value_collector = VariableValueCollector(self.constants)
+        constant_value_collector.visit(node)
+        self.constant_value = constant_value_collector.values
+        node_cp.body = [self.visit(s) for s in node_cp.body]
+        return node_cp
+
+    def visit_Assign(self, node: Assign) -> Optional[Assign]:
+        assert len(node.targets) == 1
+        t = node.targets[0]
+        if isinstance(t, Name) and t.id in self.constants:
+            return None
+        return self.generic_visit(node)
+
+    def visit_Name(self, node: Name) -> Union[Name, expr]:
+        if isinstance(node.ctx, Load) and node.id in self.constants:
+            assert (
+                node.id in self.constant_value
+            ), f"Variable {node.id} not in constant_value, accessed before assignment"
+            return self.visit(self.constant_value[node.id][0])
+        return self.generic_visit(node)

--- a/opshin/optimize/optimize_inline_constvars.py
+++ b/opshin/optimize/optimize_inline_constvars.py
@@ -4,35 +4,26 @@ from ast import *
 from copy import copy
 from collections import defaultdict
 
-from ..util import CompilingNodeVisitor, CompilingNodeTransformer, DefinedTimesVisitor
+from ..util import (
+    CompilingNodeVisitor,
+    CompilingNodeTransformer,
+    DefinedTimesVisitor,
+    NameLoadCollector,
+)
 from ..type_inference import INITIAL_SCOPE
 from ..typed_ast import TypedAnnAssign
 
 """
-Removes assignments to variables that are never read
+Inline constants that are only assigned once and only read once
 """
-
-
-class VariableValueCollector(CompilingNodeVisitor):
-    values = defaultdict(list)
-
-    def __init__(self, constants):
-        self.constants = constants
-
-    def visit_Assign(self, node: Assign) -> None:
-        assert len(node.targets) == 1
-        t = node.targets[0]
-        if isinstance(t, Name) and t.id in self.constants:
-            self.values[t.id].append(node.value)
-            return None
-        return self.generic_visit(node)
 
 
 class OptimizeInlineConstvars(CompilingNodeTransformer):
     step = "Inline variables that are constant (i.e. written only once)"
 
     constants = set()
-    constant_value = {}
+    constant_value = defaultdict(list)
+    loaded_vars = set()
 
     def visit_Module(self, node: Module) -> Module:
         # repeat until no more change due to removal
@@ -43,24 +34,33 @@ class OptimizeInlineConstvars(CompilingNodeTransformer):
         constant_collector.visit(node)
         constants = constant_collector.vars
         # if it is only assigned exactly once, it must be a constant (due to immutability)
-        self.constants = {c for c, i in constants.items() if i == 1}
-        constant_value_collector = VariableValueCollector(self.constants)
-        constant_value_collector.visit(node)
-        self.constant_value = constant_value_collector.values
+        loaded_collector = NameLoadCollector()
+        loaded_collector.visit(node)
+        loaded = loaded_collector.loaded
+        # if it is only read exactly once, there is no downside to inlining it (i.e. no multiple computations)
+        self.constants = {c for c, i in constants.items() if i == 1 and loaded[c] == 1}
         node_cp.body = [self.visit(s) for s in node_cp.body]
         return node_cp
 
     def visit_Assign(self, node: Assign) -> Optional[Assign]:
         assert len(node.targets) == 1
         t = node.targets[0]
-        if isinstance(t, Name) and t.id in self.constants:
+        if (
+            isinstance(t, Name)
+            and t.id in self.constants
+            and t.id not in self.loaded_vars
+        ):
+            # we may only replace those loaded AFTER they are assigned
+            # (otherwise a NameError could be thrown), so we will just add them here
+            self.constant_value[t.id].append(self.visit(node.value))
             return None
         return self.generic_visit(node)
 
     def visit_Name(self, node: Name) -> Union[Name, expr]:
-        if isinstance(node.ctx, Load) and node.id in self.constants:
-            assert (
-                node.id in self.constant_value
-            ), f"Variable {node.id} not in constant_value, accessed before assignment"
-            return self.visit(self.constant_value[node.id][0])
+        if isinstance(node.ctx, Load):
+            # mark the variable as loaded
+            self.loaded_vars.add(node.id)
+            if node.id in self.constant_value:
+                # Only replace those where we have a value (i.e. do not replace functions or class definitions)
+                return self.constant_value[node.id][0]
         return self.generic_visit(node)

--- a/opshin/optimize/optimize_remove_deadvars.py
+++ b/opshin/optimize/optimize_remove_deadvars.py
@@ -1,34 +1,13 @@
 from ast import *
 from copy import copy
-from collections import defaultdict
 
-from ..util import CompilingNodeVisitor, CompilingNodeTransformer
+from ..util import CompilingNodeVisitor, CompilingNodeTransformer, NameLoadCollector
 from ..type_inference import INITIAL_SCOPE
 from ..typed_ast import TypedAnnAssign
 
 """
 Removes assignments to variables that are never read
 """
-
-
-class NameLoadCollector(CompilingNodeVisitor):
-    step = "Collecting used variables"
-
-    def __init__(self):
-        self.loaded = defaultdict(int)
-
-    def visit_Name(self, node: Name) -> None:
-        if isinstance(node.ctx, Load):
-            self.loaded[node.id] += 1
-
-    def visit_ClassDef(self, node: ClassDef):
-        # ignore the content (i.e. attribute names) of class definitions
-        pass
-
-    def visit_FunctionDef(self, node: FunctionDef):
-        # ignore the type hints of function arguments
-        for s in node.body:
-            self.visit(s)
 
 
 class SafeOperationVisitor(CompilingNodeVisitor):

--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -2213,6 +2213,7 @@ def validator(
             self.assertEqual(code.stdout, code_2.stdout)
 
     def test_optimize_const_inline(self):
+        # TODO can we ensure here that the inline optimization is actually performed?
         source_code = """
 def validator(
     d: int
@@ -2227,6 +2228,7 @@ def validator(
         self.assertEqual(res, 1)
 
     def test_optimize_const_inline_complex(self):
+        # TODO can we ensure here that the inline optimization is actually performed?
         source_code = """
 def validator(
     d: int

--- a/opshin/tests/test_misc.py
+++ b/opshin/tests/test_misc.py
@@ -2211,3 +2211,31 @@ def validator(
                 capture_output=True,
             )
             self.assertEqual(code.stdout, code_2.stdout)
+
+    def test_optimize_const_inline(self):
+        source_code = """
+def validator(
+    d: int
+):
+    x = d
+    y = x
+    z = y
+    w = z
+    return w
+"""
+        res = eval_uplc_value(source_code, 1)
+        self.assertEqual(res, 1)
+
+    def test_optimize_const_inline_complex(self):
+        source_code = """
+def validator(
+    d: int
+):
+    x = d + 4
+    y = x - 1
+    z = 2 * y
+    w = 23 % z
+    return w
+"""
+        res = eval_uplc_value(source_code, 1)
+        self.assertEqual(res, (23 % (2 * ((1 + 4) - 1))))

--- a/opshin/util.py
+++ b/opshin/util.py
@@ -1,6 +1,17 @@
 from collections import defaultdict
 
-from _ast import Name, Store, ClassDef, FunctionDef, For, While, If, Import, ImportFrom
+from _ast import (
+    Name,
+    Store,
+    ClassDef,
+    FunctionDef,
+    For,
+    While,
+    If,
+    Import,
+    ImportFrom,
+    Load,
+)
 import typing
 
 import ast
@@ -243,3 +254,23 @@ class DefinedTimesVisitor(CompilingNodeVisitor):
     def visit_ImportFrom(self, node: ImportFrom):
         for n in node.names:
             self.vars[n] += 1
+
+
+class NameLoadCollector(CompilingNodeVisitor):
+    step = "Collecting used variables"
+
+    def __init__(self):
+        self.loaded = defaultdict(int)
+
+    def visit_Name(self, node: Name) -> None:
+        if isinstance(node.ctx, Load):
+            self.loaded[node.id] += 1
+
+    def visit_ClassDef(self, node: ClassDef):
+        # ignore the content (i.e. attribute names) of class definitions
+        pass
+
+    def visit_FunctionDef(self, node: FunctionDef):
+        # ignore the type hints of function arguments
+        for s in node.body:
+            self.visit(s)


### PR DESCRIPTION
This enables optimizations that concern making more readable code more efficient. For example the following
```python
def validator(x: int):
  y = x
  z = y * 2
  w = z + 4
  return w
```
will now be computationally as cheap as the spaghetti-ized version
```python
def validator(x: int):
   return (x*2)+4
   ```
   
   The optimization is only applied to variables that are read once (at this moment there is no setting to change this). In the case of reading and writing exactly once, this optimization will alway lead to less CPU/Mem steps and smaller script size. When applying the optimization to values read more than once, it may lead to a tradeoff of less steps but larger size (depending on the size of the expression that needs to be re-computed it might also increase the steps)