### PR TITLE
Improve linting output and display of warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,9 @@ script:
 - >
   coverage run -a --source=opshin -m opshin build spending examples/smart_contracts/wrapped_token.py '{"bytes": "ae810731b5d21c0d182d89c60a1eff7095dffd1c0dce8707a8611099"}' '{"bytes": "4d494c4b"}' '{"int": 1000000}' --force-three-params
 - >
-  test ! -n "$(coverage run -a --source=opshin -m opshin lint any examples/smart_contracts/wrapped_token.py)"
+  test ! -n "$(coverage run -a --source=opshin -m opshin lint any examples/smart_contracts/always_true.py)"
+- >
+  test -n "$(coverage run -a --source=opshin -m opshin lint any examples/smart_contracts/wrapped_token.py)"
 - >
   test -n "$(coverage run -a --source=opshin -m opshin lint any examples/broken.py)"
 - >

--- a/examples/datum_cast.py
+++ b/examples/datum_cast.py
@@ -22,8 +22,9 @@ def validator(d: Anything, r: Anything) -> bytes:
     e: BatchOrder = d
     # this casts the input to bytes - in the type system! In the contract this is a no-op
     r2: bytes = r
+    r3: bytes = b"1234"
     c = e.sender.payment_credential
     # this actually checks that c is of the type PubKeyCredential
     if isinstance(c, PubKeyCredential):
         res = c.credential_hash
-    return res + r2
+    return res + r2 + r3

--- a/examples/datum_cast.py
+++ b/examples/datum_cast.py
@@ -22,9 +22,8 @@ def validator(d: Anything, r: Anything) -> bytes:
     e: BatchOrder = d
     # this casts the input to bytes - in the type system! In the contract this is a no-op
     r2: bytes = r
-    r3: bytes = b"1234"
     c = e.sender.payment_credential
     # this actually checks that c is of the type PubKeyCredential
     if isinstance(c, PubKeyCredential):
         res = c.credential_hash
-    return res + r2 + r3
+    return res + r2

--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -1,6 +1,7 @@
 import inspect
 
 import argparse
+import logging
 import tempfile
 
 import cbor2
@@ -28,7 +29,7 @@ from . import (
     Purpose,
     PlutusContract,
 )
-from .util import CompilerError, data_from_json
+from .util import CompilerError, data_from_json, OPSHIN_LOG_HANDLER
 from .prelude import ScriptContext
 
 
@@ -227,6 +228,8 @@ Make sure the validator expects parameters {'datum, ' if purpose == Purpose.spen
 
 
 def perform_command(args):
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
     command = Command(args.command)
     purpose = Purpose(args.purpose)
     input_file = args.input_file if args.input_file != "-" else sys.stdin
@@ -467,6 +470,12 @@ def parse_args():
         version=f"opshin {__version__} {__copyright__}",
     )
     a.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+    a.add_argument(
         "--recursion-limit",
         default=sys.getrecursionlimit(),
         help="Modify the recursion limit (necessary for larger UPLC programs)",
@@ -481,6 +490,7 @@ def main():
     if Command(args.command) != Command.lint:
         perform_command(args)
     else:
+        OPSHIN_LOG_HANDLER.stream = sys.stdout
         try:
             perform_command(args)
         except Exception as e:

--- a/opshin/__main__.py
+++ b/opshin/__main__.py
@@ -488,9 +488,28 @@ def main():
     args = parse_args()
     sys.setrecursionlimit(args.recursion_limit)
     if Command(args.command) != Command.lint:
+        OPSHIN_LOG_HANDLER.setFormatter(
+            logging.Formatter(
+                f"%(levelname)s for {args.input_file}:%(lineno)d %(message)s"
+            )
+        )
         perform_command(args)
     else:
         OPSHIN_LOG_HANDLER.stream = sys.stdout
+        if args.output_format_json:
+            OPSHIN_LOG_HANDLER.setFormatter(
+                logging.Formatter(
+                    '{"line":%(lineno)d,"column":%(col_offset)d,"error_class":"%(levelname)s","message":"%(message)s"}'
+                )
+            )
+        else:
+            OPSHIN_LOG_HANDLER.setFormatter(
+                logging.Formatter(
+                    args.input_file
+                    + ":%(lineno)d:%(col_offset)d:%(levelname)s: %(message)s"
+                )
+            )
+
         try:
             perform_command(args)
         except Exception as e:

--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -37,8 +37,6 @@ from .typed_ast import (
     RawPlutoExpr,
 )
 
-_LOGGER = logging.getLogger(__name__)
-
 
 BoolOpMap = {
     And: plt.And,
@@ -230,7 +228,7 @@ class PlutoCompiler(CompilingNodeTransformer):
                 else:
                     possible_types = [second_last_arg.typ]
                 if any(isinstance(t, UnitType) for t in possible_types):
-                    _LOGGER.warning(
+                    OPSHIN_LOGGER.warning(
                         "The redeemer is annotated to be 'None'. This value is usually encoded in PlutusData with constructor id 0 and no fields. If you want the script to double function as minting and spending script, annotate the second argument with 'NoRedeemer'."
                     )
                 enable_double_func_mint_spend = not any(
@@ -239,7 +237,7 @@ class PlutoCompiler(CompilingNodeTransformer):
                     for t in possible_types
                 )
                 if not enable_double_func_mint_spend:
-                    _LOGGER.warning(
+                    OPSHIN_LOGGER.warning(
                         "The second argument to the validator function potentially has constructor id 0. The validator will not be able to double function as minting script and spending script."
                     )
 
@@ -331,7 +329,7 @@ class PlutoCompiler(CompilingNodeTransformer):
             except ValueError:
                 pass
             else:
-                _LOGGER.warning(
+                OPSHIN_LOGGER.warning(
                     f"The string {node.value} looks like it is supposed to be a hex-encoded bytestring but is actually utf8-encoded. Try using `bytes.fromhex('{node.value.decode()}')` instead."
                 )
         plt_val = plt.UPLCConstant(rec_constant_map(node.value))

--- a/opshin/optimize/optimize_const_folding.py
+++ b/opshin/optimize/optimize_const_folding.py
@@ -12,7 +12,7 @@ try:
 except NameError:
     from astunparse import unparse
 
-from ..util import CompilingNodeTransformer, CompilingNodeVisitor
+from ..util import CompilingNodeTransformer, CompilingNodeVisitor, OPSHIN_LOGGER
 from ..type_inference import INITIAL_SCOPE
 
 """

--- a/opshin/optimize/optimize_const_folding.py
+++ b/opshin/optimize/optimize_const_folding.py
@@ -19,7 +19,7 @@ from ..type_inference import INITIAL_SCOPE
 Pre-evaluates constant statements
 """
 
-_LOGGER = logging.getLogger(__name__)
+OPSHIN_LOGGER = logging.getLogger(__name__)
 
 ACCEPTED_ATOMIC_TYPES = [
     int,
@@ -227,7 +227,7 @@ class OptimizeConstantFolding(CompilingNodeTransformer):
         try:
             exec(unparse(node), g, l)
         except Exception as e:
-            _LOGGER.debug(e)
+            OPSHIN_LOGGER.debug(e)
         else:
             # the class is defined and added to the globals
             self.scopes_constants[-1].update(l)
@@ -259,7 +259,7 @@ class OptimizeConstantFolding(CompilingNodeTransformer):
                 # we need to pass the global dict as local dict here to make closures possible (rec functions)
                 exec(unparse(node), g, g)
             except Exception as e:
-                _LOGGER.debug(e)
+                OPSHIN_LOGGER.debug(e)
             else:
                 # the class is defined and added to the globals
                 self.scopes_constants[-1][node.name] = g[node.name]
@@ -331,7 +331,7 @@ class OptimizeConstantFolding(CompilingNodeTransformer):
             l = self._constant_vars()
             node_eval = eval(node_source, g, l)
         except Exception as e:
-            _LOGGER.debug(e)
+            OPSHIN_LOGGER.debug(e)
             return node
 
         if any(

--- a/opshin/optimize/optimize_const_folding.py
+++ b/opshin/optimize/optimize_const_folding.py
@@ -19,8 +19,6 @@ from ..type_inference import INITIAL_SCOPE
 Pre-evaluates constant statements
 """
 
-OPSHIN_LOGGER = logging.getLogger(__name__)
-
 ACCEPTED_ATOMIC_TYPES = [
     int,
     str,

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -23,8 +23,6 @@ from .rewrite.rewrite_cast_condition import SPECIAL_BOOL
 
 # from frozendict import frozendict
 
-_LOGGER = logging.getLogger(__name__)
-
 
 INITIAL_SCOPE = {
     # class annotations

--- a/opshin/typed_ast.py
+++ b/opshin/typed_ast.py
@@ -1,7 +1,5 @@
 from .types import *
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class TypedAST(AST):
     typ: Type

--- a/opshin/types.py
+++ b/opshin/types.py
@@ -11,8 +11,6 @@ import uplc.ast
 
 from .util import *
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class TypeInferenceError(AssertionError):
     pass
@@ -244,7 +242,7 @@ class AnyType(ClassType):
         return super().cmp(op, o)
 
     def stringify(self, recursive: bool = False) -> plt.AST:
-        _LOGGER.warning(
+        OPSHIN_LOGGER.warning(
             "Serializing AnyType will result in RawPlutusData (CBOR representation) to be printed without additional type information. Annotate types where possible to avoid this warning."
         )
         return OLambda(

--- a/opshin/util.py
+++ b/opshin/util.py
@@ -1,6 +1,7 @@
 from _ast import Name, Store, ClassDef, FunctionDef, Load
 from collections import defaultdict
 from copy import copy, deepcopy
+import logging
 
 import typing
 
@@ -14,6 +15,10 @@ from frozenlist2 import frozenlist
 import uplc.ast as uplc
 import pluthon as plt
 from hashlib import sha256
+
+OPSHIN_LOGGER = logging.getLogger("opshin")
+OPSHIN_LOG_HANDLER = logging.StreamHandler()
+OPSHIN_LOGGER.addHandler(OPSHIN_LOG_HANDLER)
 
 
 def distinct(xs: list):


### PR DESCRIPTION
This adjustment brings three improvements to OpShin and resolves #160 

- The `--verbose` option is added to the compiler, allowing more in-depth details about the compilation process to be seen by the user. This will allow better insights into why compilation fails or checking which optimizations have been applied
- Logger warnings are now printed together with the location in the file in which they occur. Previously, warnings have been printed without any context, making it hard to map to their origin, which is crucial for users.
- Logger warnings are among the linting output in the default linter format. This allows improving the opshin-vscode extension, that makes syntax errors easily visible in VSCode

An example for the change with the warning when compiling `examples/datum_cast.py`:

Previously:
```bash
$ opshin build examples/datum_cast.py                    
The string b'1234' looks like it is supposed to be a hex-encoded bytestring but is actually utf8-encoded. Try using `bytes.fromhex('1234')` instead.
Wrote script artifacts to build/datum_cast/
$ opshin lint examples/datum_cast.py 2> /dev/stdout
$ opshin lint examples/datum_cast.py --output-format-json 2> /dev/stdout
```


Now:
```
$ opshin build examples/datum_cast.py                    
examples/datum_cast.py:25:16:WARNING:The string b'1234' looks like it is supposed to be a hex-encoded bytestring but is actually utf8-encoded. Try using `bytes.fromhex('1234')` instead.
Wrote script artifacts to build/datum_cast/
$ opshin lint examples/datum_cast.py 2> /dev/stdout 
examples/datum_cast.py:25:16:WARNING: The string b'1234' looks like it is supposed to be a hex-encoded bytestring but is actually utf8-encoded. Try using `bytes.fromhex('1234')` instead.
$ opshin lint examples/datum_cast.py --output-format-json 2> /dev/stdout
{"line":25,"column":16,"error_class":"WARNING","message":"The string b'1234' looks like it is supposed to be a hex-encoded bytestring but is actually utf8-encoded. Try using `bytes.fromhex('1234')` instead."}

```
