### PR TITLE
Add bytes.fromhex

### DIFF
--- a/opshin/tests/test_builtins.py
+++ b/opshin/tests/test_builtins.py
@@ -415,3 +415,19 @@ def validator(x: int, y: bool, z: None) -> None:
     print(x, y, z)
         """
         eval_uplc(source_code, x, y, Unit())
+
+    @given(i=st.one_of(st.text(), st.builds(lambda x: x.hex(), st.binary())))
+    def test_fromhex(self, i):
+        source_code = """
+def validator(x: str) -> bytes:
+    return b"".fromhex(x)
+        """
+        try:
+            ret = eval_uplc_value(source_code, i)
+        except:
+            ret = None
+        try:
+            exp = bytes.fromhex(i)
+        except ValueError:
+            exp = None
+        self.assertEqual(ret, exp, "fromhex returned wrong value")

--- a/opshin/tests/test_builtins.py
+++ b/opshin/tests/test_builtins.py
@@ -416,15 +416,23 @@ def validator(x: int, y: bool, z: None) -> None:
         """
         eval_uplc(source_code, x, y, Unit())
 
-    @given(i=st.one_of(st.text(), st.builds(lambda x: x.hex(), st.binary())))
+    @given(
+        i=st.one_of(
+            st.text(),
+            st.builds(lambda x: x.hex(), st.binary()),
+            st.builds(lambda x: x.hex()[:-1], st.binary()),
+            st.builds(lambda x: x.hex().upper(), st.binary()),
+        )
+    )
+    @example("")
     def test_fromhex(self, i):
         source_code = """
 def validator(x: str) -> bytes:
     return b"".fromhex(x)
         """
         try:
-            ret = eval_uplc_value(source_code, i)
-        except:
+            ret = eval_uplc_value(source_code, i.encode("utf8"))
+        except RuntimeError as e:
             ret = None
         try:
             exp = bytes.fromhex(i)

--- a/opshin/type_impls.py
+++ b/opshin/type_impls.py
@@ -1783,10 +1783,8 @@ class ByteStringType(AtomicType):
         if attr == "fromhex":
             return InstanceType(
                 FunctionType(
-                    frozenlist([]),
-                    FunctionType(
-                        frozenlist([StringInstanceType]), ByteStringInstanceType
-                    ),
+                    frozenlist([StringInstanceType]),
+                    ByteStringInstanceType,
                 )
             )
         return super().attribute_type(attr)
@@ -1890,6 +1888,14 @@ class ByteStringType(AtomicType):
                 OLet(
                     [
                         (
+                            "bytestr",
+                            plt.EncodeUtf8(plt.Force(OVar("x"))),
+                        ),
+                        (
+                            "bytestr_len",
+                            plt.LengthOfByteString(OVar("bytestr")),
+                        ),
+                        (
                             "char_to_int",
                             OLambda(
                                 ["c"],
@@ -1940,31 +1946,24 @@ class ByteStringType(AtomicType):
                                     ),
                                 ),
                             ),
-                            (
-                                "bytestr",
-                                plt.EncodeUtf8(OVar("x")),
-                            ),
-                            (
-                                "bytestr_len",
-                                plt.LengthOfByteString(OVar("bytestr")),
-                            ),
-                            (
-                                "splitlist",
-                                plt.RecFun(
-                                    OLambda(
-                                        ["f", "i"],
+                        ),
+                        (
+                            "splitlist",
+                            plt.RecFun(
+                                OLambda(
+                                    ["f", "i"],
+                                    plt.Ite(
+                                        plt.LessThanInteger(
+                                            OVar("bytestr_len"),
+                                            plt.AddInteger(OVar("i"), plt.Integer(1)),
+                                        ),
+                                        plt.ByteString(b""),
                                         plt.Ite(
                                             plt.LessThanInteger(
-                                                OVar("bytestr_len"), OVar("i")
-                                            ),
-                                            plt.ByteString(b""),
-                                            plt.Ite(
-                                                plt.LessThanInteger(
-                                                    OVar("bytestr_len"),
-                                                    plt.AddInteger(
-                                                        OVar("i"), plt.Integer(1)
-                                                    ),
-                                                )
+                                                OVar("bytestr_len"),
+                                                plt.AddInteger(
+                                                    OVar("i"), plt.Integer(2)
+                                                ),
                                             ),
                                             plt.TraceError("Invalid hex string"),
                                             OLet(
@@ -1972,7 +1971,8 @@ class ByteStringType(AtomicType):
                                                     (
                                                         "char_at_i",
                                                         plt.IndexByteString(
-                                                            OVar("bytestr"), OVar("i")
+                                                            OVar("bytestr"),
+                                                            OVar("i"),
                                                         ),
                                                     ),
                                                     (
@@ -1986,7 +1986,7 @@ class ByteStringType(AtomicType):
                                                         ),
                                                     ),
                                                 ],
-                                                plt.MkCons(
+                                                plt.ConsByteString(
                                                     plt.AddInteger(
                                                         plt.MultiplyInteger(
                                                             plt.Apply(
@@ -2004,18 +2004,19 @@ class ByteStringType(AtomicType):
                                                         OVar("f"),
                                                         OVar("f"),
                                                         plt.AddInteger(
-                                                            OVar("i"), plt.Integer(2)
+                                                            OVar("i"),
+                                                            plt.Integer(2),
                                                         ),
                                                     ),
                                                 ),
                                             ),
                                         ),
-                                    )
-                                ),
+                                    ),
+                                )
                             ),
                         ),
                     ],
-                    plt.Apply(OVar("splitlist"), OVar("splitlist"), plt.Integer(0)),
+                    plt.Apply(OVar("splitlist"), plt.Integer(0)),
                 ),
             )
         return super().attribute(attr)

--- a/opshin/type_impls.py
+++ b/opshin/type_impls.py
@@ -1780,6 +1780,15 @@ class ByteStringType(AtomicType):
             return InstanceType(FunctionType(frozenlist([]), StringInstanceType))
         if attr == "hex":
             return InstanceType(FunctionType(frozenlist([]), StringInstanceType))
+        if attr == "fromhex":
+            return InstanceType(
+                FunctionType(
+                    frozenlist([]),
+                    FunctionType(
+                        frozenlist([StringInstanceType]), ByteStringInstanceType
+                    ),
+                )
+            )
         return super().attribute_type(attr)
 
     def attribute(self, attr) -> plt.AST:
@@ -1873,6 +1882,140 @@ class ByteStringType(AtomicType):
                             ),
                         ),
                     ),
+                ),
+            )
+        if attr == "fromhex":
+            return OLambda(
+                ["_", "x"],
+                OLet(
+                    [
+                        (
+                            "char_to_int",
+                            OLambda(
+                                ["c"],
+                                plt.Ite(
+                                    plt.And(
+                                        plt.LessThanEqualsInteger(
+                                            plt.Integer(ord("a")), OVar("c")
+                                        ),
+                                        plt.LessThanEqualsInteger(
+                                            OVar("c"), plt.Integer(ord("f"))
+                                        ),
+                                    ),
+                                    plt.AddInteger(
+                                        plt.SubtractInteger(
+                                            OVar("c"), plt.Integer(ord("a"))
+                                        ),
+                                        plt.Integer(10),
+                                    ),
+                                    plt.Ite(
+                                        plt.And(
+                                            plt.LessThanEqualsInteger(
+                                                plt.Integer(ord("0")), OVar("c")
+                                            ),
+                                            plt.LessThanEqualsInteger(
+                                                OVar("c"), plt.Integer(ord("9"))
+                                            ),
+                                        ),
+                                        plt.SubtractInteger(
+                                            OVar("c"), plt.Integer(ord("0"))
+                                        ),
+                                        plt.Ite(
+                                            plt.And(
+                                                plt.LessThanEqualsInteger(
+                                                    plt.Integer(ord("A")), OVar("c")
+                                                ),
+                                                plt.LessThanEqualsInteger(
+                                                    OVar("c"), plt.Integer(ord("F"))
+                                                ),
+                                            ),
+                                            plt.AddInteger(
+                                                plt.SubtractInteger(
+                                                    OVar("c"), plt.Integer(ord("A"))
+                                                ),
+                                                plt.Integer(10),
+                                            ),
+                                            plt.TraceError("Invalid hex character"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            (
+                                "bytestr",
+                                plt.EncodeUtf8(OVar("x")),
+                            ),
+                            (
+                                "bytestr_len",
+                                plt.LengthOfByteString(OVar("bytestr")),
+                            ),
+                            (
+                                "splitlist",
+                                plt.RecFun(
+                                    OLambda(
+                                        ["f", "i"],
+                                        plt.Ite(
+                                            plt.LessThanInteger(
+                                                OVar("bytestr_len"), OVar("i")
+                                            ),
+                                            plt.ByteString(b""),
+                                            plt.Ite(
+                                                plt.LessThanInteger(
+                                                    OVar("bytestr_len"),
+                                                    plt.AddInteger(
+                                                        OVar("i"), plt.Integer(1)
+                                                    ),
+                                                )
+                                            ),
+                                            plt.TraceError("Invalid hex string"),
+                                            OLet(
+                                                [
+                                                    (
+                                                        "char_at_i",
+                                                        plt.IndexByteString(
+                                                            OVar("bytestr"), OVar("i")
+                                                        ),
+                                                    ),
+                                                    (
+                                                        "char_at_ip1",
+                                                        plt.IndexByteString(
+                                                            OVar("bytestr"),
+                                                            plt.AddInteger(
+                                                                OVar("i"),
+                                                                plt.Integer(1),
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ],
+                                                plt.MkCons(
+                                                    plt.AddInteger(
+                                                        plt.MultiplyInteger(
+                                                            plt.Apply(
+                                                                OVar("char_to_int"),
+                                                                OVar("char_at_i"),
+                                                            ),
+                                                            plt.Integer(16),
+                                                        ),
+                                                        plt.Apply(
+                                                            OVar("char_to_int"),
+                                                            OVar("char_at_ip1"),
+                                                        ),
+                                                    ),
+                                                    plt.Apply(
+                                                        OVar("f"),
+                                                        OVar("f"),
+                                                        plt.AddInteger(
+                                                            OVar("i"), plt.Integer(2)
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                        ),
+                    ],
+                    plt.Apply(OVar("splitlist"), OVar("splitlist"), plt.Integer(0)),
                 ),
             )
         return super().attribute(attr)


### PR DESCRIPTION
This fixes #103 and currently works using the object like this

```
b"".fromhex("abcd")
bytes([]).fromhex("abcd")
```

Another implementation (using `bytes.fromhex`) will not be available without also adding #365 .