### PR TITLE
Unions of PlutusData and BuiltinData

### DIFF
--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -422,7 +422,14 @@ class PlutoCompiler(CompilingNodeTransformer):
             bind_self = node.func.typ.typ.bind_self
         bound_vs = sorted(list(node.func.typ.typ.bound_vars.keys()))
         args = []
-        for a, t in zip(node.args, node.func.typ.typ.argtyps):
+        for i, (a, t) in enumerate(zip(node.args, node.func.typ.typ.argtyps)):
+            # now impl_from_args has been chosen, skip type arg
+            if (
+                hasattr(node.func, "orig_id")
+                and node.func.orig_id == "isinstance"
+                and i == 1
+            ):
+                continue
             assert isinstance(t, InstanceType)
             # pass in all arguments evaluated with the statemonad
             a_int = self.visit(a)

--- a/opshin/fun_impls.py
+++ b/opshin/fun_impls.py
@@ -92,8 +92,6 @@ class IsinstanceImpl(PolymorphicFunction):
         assert (
             len(args) == 2
         ), f"isinstance takes two arguments [object, type], but {len(args)} were given"
-        # Plutus dataclasses isinstance is replaced by checking CONSTR_IDs
-        assert isinstance(args[1], (IntegerType, ByteStringType))
         return FunctionType(args, BoolInstanceType)
 
     def impl_from_args(self, args: typing.List[Type]) -> plt.AST:
@@ -119,6 +117,42 @@ class IsinstanceImpl(PolymorphicFunction):
                     plt.Bool(False),
                     plt.Bool(False),
                     plt.Bool(True),
+                ),
+            )
+        elif isinstance(args[1], RecordType):
+            return OLambda(
+                ["x"],
+                plt.ChooseData(
+                    OVar("x"),
+                    plt.Bool(True),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                ),
+            )
+        elif isinstance(args[1], ListType):
+            return OLambda(
+                ["x"],
+                plt.ChooseData(
+                    OVar("x"),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                    plt.Bool(True),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                ),
+            )
+        elif isinstance(args[1], DictType):
+            return OLambda(
+                ["x"],
+                plt.ChooseData(
+                    OVar("x"),
+                    plt.Bool(False),
+                    plt.Bool(True),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                    plt.Bool(False),
                 ),
             )
         else:

--- a/opshin/fun_impls.py
+++ b/opshin/fun_impls.py
@@ -87,6 +87,46 @@ class PrintImpl(PolymorphicFunction):
         return print
 
 
+class IsinstanceImpl(PolymorphicFunction):
+    def type_from_args(self, args: typing.List[Type]) -> FunctionType:
+        assert (
+            len(args) == 2
+        ), f"isinstance takes two arguments [object, type], but {len(args)} were given"
+        # Plutus dataclasses isinstance is replaced by checking CONSTR_IDs
+        assert isinstance(args[1], (IntegerType, ByteStringType))
+        return FunctionType(args, BoolInstanceType)
+
+    def impl_from_args(self, args: typing.List[Type]) -> plt.AST:
+        if isinstance(args[1], IntegerType):
+            return OLambda(
+                ["x"],
+                plt.ChooseData(
+                    OVar("x"),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                    plt.Bool(True),
+                    plt.Bool(False),
+                ),
+            )
+        elif isinstance(args[1], ByteStringType):
+            return OLambda(
+                ["x"],
+                plt.ChooseData(
+                    OVar("x"),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                    plt.Bool(False),
+                    plt.Bool(True),
+                ),
+            )
+        else:
+            raise NotImplementedError(
+                f"Only isinstance for byte, int, Plutus Dataclass types are supported"
+            )
+
+
 class PythonBuiltIn(Enum):
     all = OLambda(
         ["xs"],
@@ -437,6 +477,7 @@ class PythonBuiltIn(Enum):
             OVar("xs"), plt.BuiltIn(uplc.BuiltInFun.AddInteger), plt.Integer(0)
         ),
     )
+    isinstance = "isinstance"
 
 
 PythonBuiltInTypes = {
@@ -510,4 +551,5 @@ PythonBuiltInTypes = {
             IntegerInstanceType,
         )
     ),
+    PythonBuiltIn.isinstance: InstanceType(PolymorphicFunctionType(IsinstanceImpl())),
 }

--- a/opshin/tests/test_Unions.py
+++ b/opshin/tests/test_Unions.py
@@ -1,0 +1,242 @@
+import unittest
+
+import hypothesis
+from hypothesis import given
+from hypothesis import strategies as st
+from .utils import eval_uplc_value
+from . import PLUTUS_VM_PROFILE
+from opshin.util import CompilerError
+
+hypothesis.settings.load_profile(PLUTUS_VM_PROFILE)
+
+from .test_misc import A
+
+
+def to_int(x):
+    if isinstance(x, A):
+        return 5
+    elif isinstance(x, int):
+        return 6
+    elif isinstance(x, bytes):
+        return 7
+    elif isinstance(x, list):
+        return 8
+    elif isinstance(x, dict):
+        return 9
+    return False
+
+
+union_types = st.sampled_from([A(0), 10, b"foo", [1, 2, 3, 4, 5], {1: 2, 2: 3}])
+
+
+class Union_tests(unittest.TestCase):
+    @hypothesis.given(union_types)
+    def test_Union_types(self, x):
+        source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[A, int, bytes, List[Anything], Dict[Anything, Anything]]) -> int:
+    k: int = 0
+    if isinstance(x, A):
+        k = 5
+    elif isinstance(x, bytes):
+        k = 7
+    elif isinstance(x, int):
+        k = 6
+    elif isinstance(x, List):
+        k = 8
+    elif isinstance(x, Dict):
+        k = 9
+    return k
+"""
+        res = eval_uplc_value(source_code, x)
+        self.assertEqual(res, to_int(x))
+
+    @hypothesis.given(union_types)
+    def test_Union_types_different_order(self, x):
+        source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[A, int, bytes, List[Anything], Dict[Anything, Anything]]) -> int:
+    k: int = 1
+    if isinstance(x, int):
+        k = 6
+    elif isinstance(x, Dict):
+        k = 9
+    elif isinstance(x, bytes):
+        k = 7
+    elif isinstance(x, A):
+        k = 5
+    elif isinstance(x, List):
+        k = 8
+    return k
+"""
+        res = eval_uplc_value(source_code, x)
+        self.assertEqual(res, to_int(x))
+
+    @unittest.expectedFailure
+    def test_incorrect_Union_types(
+        self,
+    ):
+        source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[A, bytes,]) -> int:
+    k: int = 0
+    if isinstance(x, A):
+        k = 5
+    elif isinstance(x, bytes):
+        k = 7
+    elif isinstance(x, int):
+        k = 6
+    return k
+"""
+        with self.AssertRaises(CompilerError):
+            res = eval_uplc_value(source_code, 2)
+
+    def test_isinstance_Dict_subscript_fail(
+        self,
+    ):
+        source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[A, int, bytes, List[Anything], Dict[Anything, Anything]]) -> int:
+    k: int = 1
+    if isinstance(x, int):
+        k = 6
+    elif isinstance(x, Dict[Anything, Anything]):
+        k = 9
+    elif isinstance(x, bytes):
+        k = 7
+    elif isinstance(x, A):
+        k = 5
+    elif isinstance(x, List):
+        k = 8
+    return k
+"""
+        with self.assertRaises(CompilerError) as ce:
+            res = eval_uplc_value(source_code, [1, 2, 3])
+        self.assertIsInstance(ce.exception.orig_err, TypeError)
+
+    def test_isinstance_List_subscript_fail(
+        self,
+    ):
+        source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[A, int, bytes, List[Anything], Dict[Anything, Anything]]) -> int:
+    k: int = 1
+    if isinstance(x, int):
+        k = 6
+    elif isinstance(x, Dict):
+        k = 9
+    elif isinstance(x, bytes):
+        k = 7
+    elif isinstance(x, A):
+        k = 5
+    elif isinstance(x, List[Anything]):
+        k = 8
+    return k
+"""
+        with self.assertRaises(CompilerError) as ce:
+            res = eval_uplc_value(source_code, [1, 2, 3])
+        self.assertIsInstance(ce.exception.orig_err, TypeError)
+
+    def test_Union_list_is_anything(
+        self,
+    ):
+        """Test fails if List in union is anything other than List[Anything]"""
+        source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[A, int, bytes, List[int], Dict[Anything, Anything]]) -> int:
+    k: int = 1
+    if isinstance(x, int):
+        k = 6
+    elif isinstance(x, Dict):
+        k = 9
+    elif isinstance(x, bytes):
+        k = 7
+    elif isinstance(x, A):
+        k = 5
+    elif isinstance(x, List):
+        k = 8
+    return k
+"""
+        with self.assertRaises(CompilerError) as ce:
+            res = eval_uplc_value(source_code, [1, 2, 3])
+        self.assertIsInstance(ce.exception.orig_err, AssertionError)
+
+    def test_Union_dict_is_anything(
+        self,
+    ):
+        """Test fails if Dict in union is anything other than Dict[Anything, Anything]"""
+        source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[A, int, bytes, List[Anything], Dict[int, bytes]]) -> int:
+    k: int = 1
+    if isinstance(x, int):
+        k = 6
+    elif isinstance(x, Dict):
+        k = 9
+    elif isinstance(x, bytes):
+        k = 7
+    elif isinstance(x, A):
+        k = 5
+    elif isinstance(x, List):
+        k = 8
+    return k
+"""
+        with self.assertRaises(CompilerError) as ce:
+            res = eval_uplc_value(source_code, [1, 2, 3])
+        self.assertIsInstance(ce.exception.orig_err, AssertionError)

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -380,6 +380,17 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
                 ann.value, Name
             ), "Only Union, Dict and List are allowed as Generic types"
             if ann.value.orig_id == "Union":
+                for elt in ann.slice.elts:
+                    if isinstance(elt, Subscript) and elt.value.id == "List":
+                        assert (
+                            isinstance(elt.slice, Name)
+                            and elt.slice.orig_id == "Anything"
+                        ), f"Only List[Anything] is supported in Unions. Received List[{elt.slice.orig_id}]."
+                    if isinstance(elt, Subscript) and elt.value.id == "Dict":
+                        assert all(
+                            isinstance(e, Name) and e.orig_id == "Anything"
+                            for e in elt.slice.elts
+                        ), f"Only Dict[Anything, Anything] or Dict is supported in Unions. Received Dict[{elt.slice.elts[0].orig_id}, {elt.slice.elts[1].orig_id}]."
                 ann_types = frozenlist(
                     [self.type_from_annotation(e) for e in ann.slice.elts]
                 )

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -394,6 +394,21 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
                 ann_types = frozenlist(
                     [self.type_from_annotation(e) for e in ann.slice.elts]
                 )
+                # check for unique constr_ids
+                constr_ids = [
+                    record.record.constructor
+                    for record in ann_types
+                    if isinstance(record, RecordType)
+                ]
+                assert len(constr_ids) == len(
+                    set(constr_ids)
+                ), f"Duplicate constr_ids for records in Union: " + str(
+                    {
+                        t.record.orig_name: t.record.constructor
+                        for t in ann_types
+                        if isinstance(t, RecordType)
+                    }
+                )
                 return union_types(*ann_types)
             if ann.value.orig_id == "List":
                 ann_type = self.type_from_annotation(ann.slice)
@@ -836,6 +851,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
             "Dict",
             "List",
         ]:
+
             ts.value = ts.typ = self.type_from_annotation(ts)
             return ts
 


### PR DESCRIPTION
 Targeting issue #367 
The following would now compile
```
source_code = """
from dataclasses import dataclass
from typing import Dict, List, Union
from pycardano import Datum as Anything, PlutusData

@dataclass()
class A(PlutusData):
    CONSTR_ID = 0
    foo: int

def validator(x: Union[A, int, bytes, List[int], Dict[int, int]]) -> int:
    k: int = 0
    if isinstance(x, A):
        k = 5
    elif isinstance(x, bytes):
        k = 7
    elif isinstance(x, int):
        k = 6
    elif isinstance(x, List[int]):
        k = 8
    elif isinstance(x, Dict[int, int]):
        k = 9
    return k
"""
```

I think it can't currently distinguish between `Dict[int, int]` and `Dict[int, bytes]` for example. I'll work on that if you think this is heading in the correct direction. I also need to sit down and think of what edge cases might break this and write some more tests.