### PR TITLE
Fix True/False swapped constructors

### DIFF
--- a/opshin/ledger/api_v2.py
+++ b/opshin/ledger/api_v2.py
@@ -32,7 +32,7 @@ class TrueData(PlutusData):
     Example value: TrueData()
     """
 
-    CONSTR_ID = 0
+    CONSTR_ID = 1
 
 
 @dataclass(unsafe_hash=True)
@@ -44,7 +44,7 @@ class FalseData(PlutusData):
     Example value: FalseData()
     """
 
-    CONSTR_ID = 1
+    CONSTR_ID = 0
 
 
 # A Datum that represents a boolean value in Haskell implementations.

--- a/opshin/ledger/api_v3.py
+++ b/opshin/ledger/api_v3.py
@@ -34,7 +34,7 @@ class TrueData(PlutusData):
     Example value: TrueData()
     """
 
-    CONSTR_ID = 0
+    CONSTR_ID = 1
 
 
 @dataclass(unsafe_hash=True)
@@ -46,7 +46,7 @@ class FalseData(PlutusData):
     Example value: FalseData()
     """
 
-    CONSTR_ID = 1
+    CONSTR_ID = 0
 
 
 # A Datum that represents a boolean value in Haskell implementations.
@@ -66,8 +66,17 @@ class BoxedInt(PlutusData):
     value: int
 
 
+@dataclass(unsafe_hash=True)
+class NoValue(PlutusData):
+    """
+    An empty value (None case of Optional / Maybe)
+    """
+
+    CONSTR_ID = 1
+
+
 Lovelace = int
-OptionalInt = Union[BoxedInt, FalseData]
+OptionalInt = Union[BoxedInt, NoValue]
 OptionalLovelace = OptionalInt
 
 

--- a/tests/test_ledger/test_api_v3.py
+++ b/tests/test_ledger/test_api_v3.py
@@ -74,10 +74,10 @@ def test_script_context_mapping():
             withdrawals={},
             validity_range=POSIXTimeRange(
                 lower_bound=LowerBoundPOSIXTime(
-                    limit=FinitePOSIXTime(time=1745501373000), closed=FalseData()
+                    limit=FinitePOSIXTime(time=1745501373000), closed=TrueData()
                 ),
                 upper_bound=UpperBoundPOSIXTime(
-                    limit=FinitePOSIXTime(time=1745502383000), closed=TrueData()
+                    limit=FinitePOSIXTime(time=1745502383000), closed=FalseData()
                 ),
             ),
             signatories=[],


### PR DESCRIPTION
This fix resolves Finding 9 by the anastasia labs report: https://github.com/Anastasia-Labs/opshin-audit/blob/mileston2-progress/catalyst_docs/milestone2/milestone2_langanalysis.md#finding-09---falsedata-and-truedata-uses-the-wrong-constr_id