### PR TITLE
Feat line number in error messages.

### DIFF
--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -29,10 +29,7 @@ from .rewrite.rewrite_tuple_assign import RewriteTupleAssign
 from .optimize.optimize_remove_pass import OptimizeRemovePass
 from .optimize.optimize_remove_deadvars import OptimizeRemoveDeadvars, NameLoadCollector
 from .type_inference import *
-from .util import (
-    CompilingNodeTransformer,
-    NoOp,
-)
+from .util import CompilingNodeTransformer, NoOp, format_error_trace
 from .typed_ast import (
     transform_ext_params_map,
     transform_output_map,
@@ -289,7 +286,15 @@ class PlutoCompiler(CompilingNodeTransformer):
                         (
                             x,
                             plt.Delay(
-                                plt.TraceError(f"NameError: {map_to_orig_name(x)}")
+                                plt.TraceError(
+                                    format_error_trace(
+                                        self.config.format_error_trace,
+                                        f"NameError: {map_to_orig_name(x)}",
+                                        name_load_visitor.loaded.get(
+                                            x, [main_fun.lineno]
+                                        ),
+                                    ),
+                                )
                             ),
                         )
                         for x in all_vs
@@ -321,7 +326,15 @@ class PlutoCompiler(CompilingNodeTransformer):
                 [
                     (
                         x,
-                        plt.Delay(plt.TraceError(f"NameError: {map_to_orig_name(x)}")),
+                        plt.Delay(
+                            plt.TraceError(
+                                format_error_trace(
+                                    self.config.format_error_trace,
+                                    f"NameError: {map_to_orig_name(x)}",
+                                    name_load_visitor.loaded.get(x, [main_fun.lineno]),
+                                )
+                            ),
+                        ),
                     )
                     for x in all_vs
                 ],
@@ -782,7 +795,13 @@ class PlutoCompiler(CompilingNodeTransformer):
                                         plt.FstPair(OVar("x")),
                                     ),
                                 ),
-                                plt.TraceError("KeyError"),
+                                plt.TraceError(
+                                    format_error_trace(
+                                        self.config.format_error_trace,
+                                        "KeyError",
+                                        node.lineno,
+                                    )
+                                ),
                             )
                         ),
                     ),

--- a/opshin/compiler_config.py
+++ b/opshin/compiler_config.py
@@ -11,6 +11,7 @@ class CompilationConfig(pluthon.CompilationConfig):
     force_three_params: Optional[bool] = None
     remove_dead_code: Optional[bool] = None
     fast_access_skip: Optional[int] = None
+    format_error_trace: Optional[str] = None
 
 
 # The default configuration for the compiler
@@ -20,6 +21,7 @@ OPT_O0_CONFIG = (
     .update(
         constant_folding=False,
         remove_dead_code=False,
+        format_error_trace="{error}",
     )
 )
 OPT_O1_CONFIG = (
@@ -69,6 +71,10 @@ ARGPARSE_ARGS.update(
         "fast_access_skip": {
             "help": "How many steps to skip for fast list index access, default None means no steps are skipped (useful if long lists are common).",
             "type": int,
+        },
+        "format_error_trace": {
+            "help": "Customize error trace format string. Currently supported placeholders are {error} for the error msg and {line_number} for the line number in the source code. Example: 'Error {error} on line {line_number}'",
+            "type": str,
         },
     }
 )

--- a/opshin/optimize/optimize_remove_deadvars.py
+++ b/opshin/optimize/optimize_remove_deadvars.py
@@ -17,11 +17,11 @@ class NameLoadCollector(CompilingNodeVisitor):
     step = "Collecting used variables"
 
     def __init__(self):
-        self.loaded = defaultdict(int)
+        self.loaded = defaultdict(list)
 
     def visit_Name(self, node: TypedName) -> None:
         if isinstance(node.ctx, Load):
-            self.loaded[node.id] += 1
+            self.loaded[node.id].append(node.lineno)
 
     def visit_ClassDef(self, node: TypedClassDef):
         # ignore the content (i.e. attribute names) of class definitions
@@ -32,9 +32,9 @@ class NameLoadCollector(CompilingNodeVisitor):
         for s in node.body:
             self.visit(s)
         for v in node.typ.typ.bound_vars.keys():
-            self.loaded[v] += 1
+            self.loaded[v].append(node.lineno)
         if node.typ.typ.bind_self is not None:
-            self.loaded[node.typ.typ.bind_self] += 1
+            self.loaded[node.typ.typ.bind_self].append(node.lineno)
 
 
 class SafeOperationVisitor(CompilingNodeVisitor):


### PR DESCRIPTION
Targetting #54 

Implementing some way to customize error messages such as by adding the lineno of the source code line that caused that error.

This pull request adds a configuration option:
config = opshin.DEFAULT_CONFIG.update(format_error_trace = <custom_error_str>)
where {error} and {line_number} are currently supported placeholders.

For example

```
from tests.utils import eval_uplc_raw
from opshin import DEFAULT_CONFIG

source_code = """
def validator(x: int) -> int:
    if x > 10:
        y = 5
    return y
"""
config = DEFAULT_CONFIG.update(
    format_error_trace="Error: {error} at line {line_number}"
)
print(eval_uplc_raw(source_code, 4, config=config))

```
gives:
`ComputationResult(result=RuntimeError('Execution called Error'), logs=['Error: NameError: y at line 5'], cost=Budget(cpu=2615762, memory=9166))`


