### PR TITLE
Check that aliasing check_integrity is properly implemented

### DIFF
--- a/opshin/rewrite/rewrite_import.py
+++ b/opshin/rewrite/rewrite_import.py
@@ -52,6 +52,16 @@ class RewriteLocation(CompilingNodeTransformer):
         return super().visit(node)
 
 
+SPECIAL_IMPORTS = [
+    "pycardano",
+    "typing",
+    "dataclasses",
+    "hashlib",
+    "opshin.bridge",
+    "opshin.std.integrity",
+]
+
+
 class RewriteImport(CompilingNodeTransformer):
     step = "Resolving imports"
 
@@ -63,24 +73,12 @@ class RewriteImport(CompilingNodeTransformer):
     def visit_ImportFrom(
         self, node: ImportFrom
     ) -> typing.Union[ImportFrom, typing.List[AST], None]:
-        if node.module in [
-            "pycardano",
-            "typing",
-            "dataclasses",
-            "hashlib",
-            "opshin.bridge",
-            "opshin.std.integrity",
-        ]:
+        if node.module in SPECIAL_IMPORTS:
             return node
-        assert (
-            len(node.names) == 1
-        ), "The import must have the form 'from <pkg> import *'"
-        assert (
-            node.names[0].name == "*"
-        ), "The import must have the form 'from <pkg> import *'"
-        assert (
-            node.names[0].asname == None
-        ), "The import must have the form 'from <pkg> import *'"
+        error_msg = f"The import must have the form 'from <pkg> import *' or import from one of the special modules {', '.join(SPECIAL_IMPORTS)}"
+        assert len(node.names) == 1, error_msg
+        assert node.names[0].name == "*", error_msg
+        assert node.names[0].asname == None, error_msg
         # TODO set anchor point according to own package
         if self.filename:
             sys.path.append(str(pathlib.Path(self.filename).parent.absolute()))

--- a/opshin/rewrite/rewrite_import_hashlib.py
+++ b/opshin/rewrite/rewrite_import_hashlib.py
@@ -26,6 +26,9 @@ class HashType(ClassType):
     def __ge__(self, other):
         return isinstance(other, HashType)
 
+    def python_type(self):
+        return "HashFunction"
+
 
 HashInstanceType = InstanceType(HashType())
 

--- a/opshin/rewrite/rewrite_import_integrity_check.py
+++ b/opshin/rewrite/rewrite_import_integrity_check.py
@@ -54,7 +54,7 @@ class RewriteImportIntegrityCheck(CompilingNodeTransformer):
             ), "Imports something other from the integrity check than the integrity check builtin"
             renamed = n.asname if n.asname is not None else n.name
             assert (
-                renamed not in INITIAL_SCOPE
+                renamed not in INITIAL_SCOPE or renamed == FunctionName
             ), f"Name '{renamed}' is a reserved name, cannot import {FunctionName} with that name."
             INITIAL_SCOPE[renamed] = InstanceType(
                 PolymorphicFunctionType(IntegrityCheckImpl())

--- a/opshin/rewrite/rewrite_import_integrity_check.py
+++ b/opshin/rewrite/rewrite_import_integrity_check.py
@@ -53,6 +53,9 @@ class RewriteImportIntegrityCheck(CompilingNodeTransformer):
                 n.name == FunctionName
             ), "Imports something other from the integrity check than the integrity check builtin"
             renamed = n.asname if n.asname is not None else n.name
+            assert (
+                renamed not in INITIAL_SCOPE
+            ), f"Name '{renamed}' is a reserved name, cannot import {FunctionName} with that name."
             INITIAL_SCOPE[renamed] = InstanceType(
                 PolymorphicFunctionType(IntegrityCheckImpl())
             )

--- a/opshin/type_impls.py
+++ b/opshin/type_impls.py
@@ -2692,6 +2692,9 @@ class InaccessibleType(ClassType):
 
     pass
 
+    def python_type(self):
+        return "<forbidden>"
+
 
 def repeated_addition(zero, add):
     # this is optimized for logarithmic complexity by exponentiation by squaring
@@ -3047,11 +3050,19 @@ class PolymorphicFunctionType(ClassType):
             and self.polymorphic_function == other.polymorphic_function
         )
 
+    def python_type(self):
+        return (
+            f"PolymorphicFunctionType({self.polymorphic_function.__class__.__name__})"
+        )
+
 
 @dataclass(frozen=True, unsafe_hash=True)
 class PolymorphicFunctionInstanceType(InstanceType):
     typ: FunctionType
     polymorphic_function: PolymorphicFunction
+
+    def python_type(self):
+        return self.typ.python_type()
 
 
 EmptyListMap = {

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -264,11 +264,11 @@ def merge_scope(s1: typing.Dict[str, Type], s2: typing.Dict[str, Type]):
             try:
                 assert isinstance(s1[k], InstanceType) and isinstance(
                     s2[k], InstanceType
-                ), "Can only merge instance types"
+                ), f"""Can only merge instance types, found class type '{s1[k].python_type() if not isinstance(s1[k], InstanceType) else s2[k].python_type() if not isinstance(s2[k], InstanceType) else s1[k].python_type() + "' and '" + s1[k].python_type()}' for '{k}'"""
                 merged[k] = InstanceType(union_types(s1[k].typ, s2[k].typ))
             except AssertionError as e:
                 raise AssertionError(
-                    f"Can not merge scopes after branching, conflicting types for {k}: {e}"
+                    f"Can not merge scopes after branching, conflicting types for '{k}': '{e}'"
                 )
     return merged
 
@@ -299,12 +299,12 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
         if outer_scope_type is None:
             # If the variable is not found in any scope, raise an error
             raise TypeInferenceError(
-                f"Variable {map_to_orig_name(name)} not initialized at access. You need to define it before using it the first time."
+                f"Variable '{map_to_orig_name(name)}' not initialized at access. You need to define it before using it the first time."
             )
         else:
             raise TypeInferenceError(
-                f"Variable {map_to_orig_name(name)} not initialized at access.\n"
-                f"Note that you may be trying to access variable {map_to_orig_name(name)} of type {outer_scope_type.python_type()} in an outer scope and later redefine it. This is not allowed.\n"
+                f"Variable '{map_to_orig_name(name)}' not initialized at access.\n"
+                f"Note that you may be trying to access variable '{map_to_orig_name(name)}' of type '{outer_scope_type.python_type()}' in an outer scope and later redefine it. This is not allowed.\n"
                 "This can happen for example if you redefine a (renamed) imported function but try to use it before the redefinition."
             )
 
@@ -320,7 +320,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
                 # the specified type is broader, we pass on this
                 return
             raise TypeInferenceError(
-                f"Type {self.scopes[-1][name]} of variable {map_to_orig_name(name)} in local scope does not match inferred type {typ}"
+                f"Type '{self.scopes[-1][name].python_type()}' of variable '{map_to_orig_name(name)}' in local scope does not match inferred type '{typ.python_type()}'"
             )
         self.scopes[-1][name] = typ
 
@@ -1077,7 +1077,6 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
             tc.func = self.visit(node.func)
         except Exception as e:
             # might be a method, duck test for class_name, method_name should
-            raise e
             try:
                 func_variable_type = self.variable_type(tc.func.value.id)
                 class_name = func_variable_type.typ.record.name

--- a/tests/test_hashlib.py
+++ b/tests/test_hashlib.py
@@ -67,6 +67,7 @@ def validator(b: bytes) -> bytes:
 """
     try:
         builder._compile(source_code)
+        assert False, "Expected an error due to import conflict"
     except Exception as e:
         assert (
             "import" in str(e).lower() and "hash" in str(e).lower()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3187,3 +3187,21 @@ def validator(a: int) -> int:
 """
         # this should pass during compilation because t3 is guaranteed to have a second element
         builder._compile(source_code)
+
+    def test_import_integritycheck_reserved_name(self):
+        source_code = """
+from opshin.std.integrity import check_integrity as bytes
+
+def validator(a: int) -> int:
+    return a
+    
+"""
+        try:
+            builder._compile(source_code)
+            self.fail("Integrity check did not catch reserved name")
+        except Exception as e:
+            self.assertIn(
+                "reserved",
+                str(e),
+                "Integrity check did not catch reserved name",
+            )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3205,3 +3205,19 @@ def validator(a: int) -> int:
                 str(e),
                 "Integrity check did not catch reserved name",
             )
+
+    def test_type_change_error_message(self):
+        source_code = """
+def validator(a: int) -> int:
+    a = 1
+    a = "hello"
+    return a
+
+"""
+        try:
+            builder._compile(source_code)
+            self.fail("Type check did not fail")
+        except Exception as e:
+            assert "int" in str(e) and "str" in str(
+                e
+            ), "Type check did not fail with correct message"


### PR DESCRIPTION
This resolves part 2 of ID-M403 in the OpShin Audit Report.

It also adds a more friendly error message in general when type errors stem from shadowing an outer variable, i.e.

```
x = 1
def foo():
   y = x
   x = 2
```
Would previously simply throw "not initialized at access" error, but now points to the fact that an outer variable with the same name is defined but later redefined if such a variable can be found. Note: this would simply throw a runtime error in CPython