### PR TITLE
Reduce the number of NameErrors in contract constructions

### DIFF
--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -279,7 +279,7 @@ class PlutoCompiler(CompilingNodeTransformer):
             self.current_function_typ.append(FunctionType([], InstanceType(AnyType())))
             name_load_visitor = NameLoadCollector()
             name_load_visitor.visit(node)
-            all_vs = sorted(set(all_vars(node)) | set(name_load_visitor.loaded.keys()))
+            all_vs = sorted(set(name_load_visitor.loaded.keys()))
 
             # write all variables that are ever read
             # once at the beginning so that we can always access them (only potentially causing a nameerror at runtime)
@@ -313,7 +313,7 @@ class PlutoCompiler(CompilingNodeTransformer):
         else:
             name_load_visitor = NameLoadCollector()
             name_load_visitor.visit(node)
-            all_vs = sorted(set(all_vars(node)) | set(name_load_visitor.loaded.keys()))
+            all_vs = sorted(set(name_load_visitor.loaded.keys()))
 
             body = node.body
             # write all variables that are ever read


### PR DESCRIPTION
Previously, all variables (either stored or loaded) would be initialized once in the beginning with a NameError node. This is not generally necessary and has now been reduced to only those variables that are loaded at any point.