### PR TITLE
Raise an error when importing in the wrong format

### DIFF
--- a/opshin/rewrite/rewrite_import.py
+++ b/opshin/rewrite/rewrite_import.py
@@ -70,6 +70,10 @@ class RewriteImport(CompilingNodeTransformer):
         self.package = package
         self.resolved_imports = resolved_imports or OrderedSet()
 
+    def visit_Import(self, node):
+        error_msg = f"The import must have the form 'from <pkg> import *' or import from one of the special modules {', '.join(SPECIAL_IMPORTS)}"
+        raise SyntaxError(error_msg)
+
     def visit_ImportFrom(
         self, node: ImportFrom
     ) -> typing.Union[ImportFrom, typing.List[AST], None]:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -11,6 +11,7 @@ import unittest
 import frozendict
 import frozenlist2
 import hypothesis
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from parameterized import parameterized
@@ -1120,6 +1121,9 @@ def validator(c: ScriptContext) -> str:
         """
         res = eval_uplc_value(source_code, context)
         # should not raise
+        from pycardano import RawPlutusData  # noqa: F401
+        from cbor2 import CBORTag  # noqa: F401
+
         eval(res)
 
     @hypothesis.given(st.binary(), st.binary())

--- a/tests/test_rewrite/test_import.py
+++ b/tests/test_rewrite/test_import.py
@@ -1,0 +1,29 @@
+from opshin import builder, CompilerError
+
+
+def test_import_without_from():
+    source_code = """
+import opshin.prelude
+
+def validator(a: int) -> int:
+    return opshin.prelude.add(a, 1)
+    """
+    try:
+        builder._compile(source_code)
+        assert False, "Expected compilation failure due to import without from"
+    except CompilerError as e:
+        assert "import" in str(e).lower(), "Unexpected error message"
+
+
+def test_import_without_from_with_as():
+    source_code = """
+import opshin.prelude as prelude
+
+def validator(a: int) -> int:
+    return prelude.add(a, 1)
+    """
+    try:
+        builder._compile(source_code)
+        assert False, "Expected compilation failure due to import without from"
+    except CompilerError as e:
+        assert "import" in str(e).lower(), "Unexpected error message"


### PR DESCRIPTION
This addresses ID-U402 in the OpShin Audit Report. Now a useful error is thrown when importing.