### PR TITLE
Fix dictionaries and lists that contain unions of builtin data

### DIFF
--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -926,9 +926,14 @@ class PlutoCompiler(CompilingNodeTransformer):
     def visit_List(self, node: TypedList) -> plt.AST:
         assert isinstance(node.typ, InstanceType)
         assert isinstance(node.typ.typ, ListType)
-        l = empty_list(node.typ.typ.typ)
+        el_typ = node.typ.typ.typ
+        l = empty_list(el_typ)
         for e in reversed(node.elts):
-            l = plt.MkCons(self.visit(e), l)
+            element = self.visit(e)
+            if isinstance(el_typ.typ, AnyType) or isinstance(el_typ.typ, UnionType):
+                # if the function expects input of generic type data, wrap data before passing it inside
+                element = transform_output_map(e.typ)(element)
+            l = plt.MkCons(element, l)
         return l
 
     def visit_Dict(self, node: TypedDict) -> plt.AST:

--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -791,7 +791,7 @@ class PlutoCompiler(CompilingNodeTransformer):
                                 OLambda(
                                     ["x"],
                                     plt.EqualsData(
-                                        transform_output_map(dict_typ.key_typ)(
+                                        transform_output_map(node.slice.typ)(
                                             OVar("key")
                                         ),
                                         plt.FstPair(OVar("x")),
@@ -945,10 +945,10 @@ class PlutoCompiler(CompilingNodeTransformer):
         for k, v in zip(node.keys, node.values):
             l = plt.MkCons(
                 plt.MkPairData(
-                    transform_output_map(key_type)(
+                    transform_output_map(k.typ)(
                         self.visit(k),
                     ),
-                    transform_output_map(value_type)(
+                    transform_output_map(v.typ)(
                         self.visit(v),
                     ),
                 ),

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -1022,7 +1022,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
                 ts.slice = self.visit(node.slice)
                 assert (
                     ts.slice.typ == ts.value.typ.typ.key_typ
-                ), f"Dict subscript must have dict key type {ts.value.typ.typ.key_typ} but has type {ts.slice.typ}"
+                ), f"Dict subscript must have dict key type {ts.value.typ.typ.key_typ.python_type()} but has type {ts.slice.typ.python_type()}"
                 ts.typ = ts.value.typ.typ.value_typ
             else:
                 raise TypeInferenceError(
@@ -1030,7 +1030,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
                 )
         else:
             raise TypeInferenceError(
-                f"Could not infer type of subscript of typ {ts.value.typ.__class__}"
+                f"Could not infer type of subscript of typ {ts.value.typ.python_type()}"
             )
         return ts
 

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -579,7 +579,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
         l_typ = tt.elts[0].typ
         assert all(
             l_typ >= e.typ for e in tt.elts
-        ), f"All elements of a list must have the same type, has typs {tuple(e.typ for e in tt.elts)}"
+        ), f"All elements of a list must have the same type, has typs {tuple(e.typ.python_type() for e in tt.elts)}"
         tt.typ = InstanceType(ListType(l_typ))
         return tt
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -11,6 +11,7 @@ import unittest
 import frozendict
 import frozenlist2
 import hypothesis
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from parameterized import parameterized
@@ -1120,6 +1121,9 @@ def validator(c: ScriptContext) -> str:
         """
         res = eval_uplc_value(source_code, context)
         # should not raise
+        from pycardano import RawPlutusData  # noqa: F401
+        from cbor2 import CBORTag  # noqa: F401
+
         eval(res)
 
     @hypothesis.given(st.binary(), st.binary())

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -103,3 +103,105 @@ def validator(x: Union[int, bytes]) -> Union[int, bytes]:
     # primarily test that this does not fail to compile
     res = eval_uplc_value(source_code, 5)
     assert res == 5
+
+
+def test_type_inference_list_3():
+    source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: int) -> int:
+    l = [10, b"hello"]
+    return l[x]
+"""
+    # primarily test that this does not fail to compile
+    res = eval_uplc_value(source_code, 0)
+    assert res == 10
+    res = eval_uplc_value(source_code, 1)
+    assert res == b"hello"
+
+
+def test_type_inference_dict():
+    source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[int, bytes]) -> Union[int, bytes]:
+    l = {1: x, 2: 10, 3: b"hello"}
+    return l[2]
+"""
+    # primarily test that this does not fail to compile
+    res = eval_uplc_value(source_code, 5)
+    assert res == 10
+
+
+def test_type_inference_dict_2():
+    source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[int, bytes]) -> Union[int, bytes]:
+    l = {1: 10, 2: x, 3: b"hello"}
+    return l[1]
+"""
+    # primarily test that this does not fail to compile
+    res = eval_uplc_value(source_code, 5)
+    assert res == 10
+
+
+def test_type_inference_dict_3():
+    source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[int, bytes]) -> Union[int, bytes]:
+    l = {1: 10, x: 20, b"hi": 30}
+    return l[1]
+"""
+    # primarily test that this does not fail to compile
+    res = eval_uplc_value(source_code, 5)
+    assert res == 10
+
+
+def test_type_inference_dict_4():
+    source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[int, bytes]) -> Union[int, bytes]:
+    l = {x: 10, 2: 20, b"hi": 30}
+    return l[2]
+"""
+    # primarily test that this does not fail to compile
+    res = eval_uplc_value(source_code, 5)
+    assert res == 20

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -205,3 +205,23 @@ def validator(x: Union[int, bytes]) -> Union[int, bytes]:
     # primarily test that this does not fail to compile
     res = eval_uplc_value(source_code, 5)
     assert res == 20
+
+
+def test_type_inference_dict_5():
+    source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[int, bytes]) -> Union[int, bytes]:
+    l = {x: 10, 2: 20, b"hi": 30}
+    return l[x]
+"""
+    # primarily test that this does not fail to compile
+    res = eval_uplc_value(source_code, 5)
+    assert res == 10

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 from opshin.type_impls import *
+from tests.utils import eval_uplc_value
 
 
 def test_record_type_order():
@@ -62,3 +63,43 @@ def test_tuple_size_order():
     assert not abc >= ac
     assert ab >= abc
     assert ac >= abc
+
+
+def test_type_inference_list():
+    source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[int, bytes]) -> Union[int, bytes]:
+    l = [x, 10, b"hello"]
+    return l[1]
+"""
+    # primarily test that this does not fail to compile
+    res = eval_uplc_value(source_code, 5)
+    assert res == 10
+
+
+def test_type_inference_list_2():
+    source_code = """
+from dataclasses import dataclass
+from typing import Dict, List, Union
+from pycardano import Datum as Anything, PlutusData
+
+@dataclass()
+class A(PlutusData):
+    CONSTR_ID = 0
+    foo: int
+
+def validator(x: Union[int, bytes]) -> Union[int, bytes]:
+    l = [10, x, b"hello"]
+    return l[1]
+"""
+    # primarily test that this does not fail to compile
+    res = eval_uplc_value(source_code, 5)
+    assert res == 5

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -116,7 +116,7 @@ class A(PlutusData):
     CONSTR_ID = 0
     foo: int
 
-def validator(x: int) -> int:
+def validator(x: int) -> Union[int, bytes]:
     l = [10, b"hello"]
     return l[x]
 """


### PR DESCRIPTION
This addresses audit report ID-U406. Now OpShin automatically derives the maximum type for all elements in the list in order to determine whether they can be unioned into the list.