### PR TITLE
Add radd and other reverse dunder methods, generally clean up dunder code

### DIFF
--- a/opshin/std/fractions.py
+++ b/opshin/std/fractions.py
@@ -96,6 +96,15 @@ class Fraction(PlutusData):
         else:
             return Fraction(self.numerator, self.denominator * other)
 
+    def __pow__(self, exponent: int) -> "Fraction":
+        """returns self ** exponent, where exponent is an integer"""
+        if exponent >= 0:
+            return Fraction(self.numerator**exponent, self.denominator**exponent)
+        else:
+            return Fraction(
+                self.denominator ** (-exponent), self.numerator ** (-exponent)
+            )
+
     def __ge__(self, other: Union["Fraction", int]) -> bool:
         """returns self >= other"""
         if isinstance(other, Fraction):
@@ -195,6 +204,28 @@ class Fraction(PlutusData):
             return x.numerator // x.denominator
         else:
             return self.numerator // (other * self.denominator)
+
+    def __radd__(self, other: Union["Fraction", int]) -> "Fraction":
+        return self + other
+
+    def __rsub__(self, other: Union["Fraction", int]) -> "Fraction":
+        return -self + other
+
+    def __rmul__(self, other: Union["Fraction", int]) -> "Fraction":
+        return self * other
+
+    def __rtruediv__(self, other: Union["Fraction", int]) -> "Fraction":
+        if isinstance(other, Fraction):
+            return other / self
+        else:
+            return Fraction(other * self.denominator, self.numerator)
+
+    def __rfloordiv__(self, other: Union["Fraction", int]) -> int:
+        if isinstance(other, Fraction):
+            return other // self
+        else:
+            x = Fraction(other, 1) / self
+            return x.numerator // x.denominator
 
 
 def _norm_signs_fraction(a: Fraction) -> Fraction:

--- a/opshin/type_impls.py
+++ b/opshin/type_impls.py
@@ -1856,6 +1856,8 @@ class IntegerType(AtomicType):
         )
 
     def _binop_return_type(self, binop: operator, other: "Type") -> "Type":
+        if isinstance(other, InstanceType) and isinstance(other.typ, RecordType):
+            print("Ha")
         if (
             isinstance(binop, Add)
             or isinstance(binop, Sub)

--- a/opshin/type_impls.py
+++ b/opshin/type_impls.py
@@ -1876,7 +1876,7 @@ class IntegerType(AtomicType):
                 return ByteStringType()
             elif other == StringInstanceType:
                 return StringType()
-        return super().binop_type(binop, other)
+        return super()._binop_return_type(binop, other)
 
     def _binop_bin_fun(self, binop: operator, other: AST):
         if other.typ == IntegerInstanceType:
@@ -2010,7 +2010,7 @@ class StringType(AtomicType):
         if isinstance(binop, Mult):
             if other == IntegerInstanceType:
                 return StringType()
-        return super().binop_type(binop, other)
+        return super()._binop_return_type(binop, other)
 
     def _binop_bin_fun(self, binop: operator, other: AST):
         if isinstance(binop, Add):

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -431,19 +431,19 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
                     args=args,
                     keywords=[],
                 )
-                call.func.orig_id = None
+                call.func.orig_id = f"{operand_class_name}.{dunder}"
                 call.func.id = method_name
                 return self.visit_Call(call)
         # if this is not supported, try the reverse dunder
         # note we assume 1, i.e. allow only a single right operand
-        right_op = args[0] if len(args) == 1 else None
+        right_op_typ = args[0].typ if len(args) == 1 else None
         if (
             operation.__class__ in DUNDER_REVERSE_MAP
-            and isinstance(right_op, InstanceType)
-            and isinstance(right_op.typ, RecordType)
+            and isinstance(right_op_typ, InstanceType)
+            and isinstance(right_op_typ.typ, RecordType)
         ):
             dunder = DUNDER_REVERSE_MAP[operation.__class__]
-            right_class_name = right_op.typ.record.name
+            right_class_name = right_op_typ.typ.record.name
             method_name = f"{right_class_name}_+_{dunder}"
             if any([method_name in scope for scope in self.scopes]):
                 call = ast.Call(
@@ -452,10 +452,10 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
                         attr=dunder,
                         ctx=ast.Load(),
                     ),
-                    args=operand,
+                    args=[operand],
                     keywords=[],
                 )
-                call.func.orig_id = None
+                call.func.orig_id = f"{right_class_name}.{dunder}"
                 call.func.id = method_name
                 return self.visit_Call(call)
         return None

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -371,7 +371,7 @@ def validator(x: Union[int,bytes,List[Anything],Dict[Anything,Anything]]) -> str
         """
         ret = eval_uplc_value(source_code, x)
         if isinstance(x, (int, bytes)):
-            if "'" in str(x) and not "\\" in ret.decode("utf8"):
+            if "'" in str(x) and not "\\" in str(x):
                 return
             self.assertEqual(ret.decode("utf8"), str(x), "str returned wrong value")
 

--- a/tests/test_class_methods.py
+++ b/tests/test_class_methods.py
@@ -1,7 +1,7 @@
 import unittest
 
 import hypothesis
-from hypothesis import given
+from hypothesis import given, example
 from hypothesis import strategies as st
 from .utils import eval_uplc_value
 from . import PLUTUS_VM_PROFILE
@@ -527,6 +527,26 @@ class Foo(PlutusData):
 def validator(a: int, b: int, c:int) -> bool:
     foo1 = Foo(a, b)
     return c not in foo1
+"""
+        ret = eval_uplc_value(source_code, x, y, z)
+        self.assertEqual(ret, z not in [x, y])
+
+    @given(x=st.integers(), y=st.integers(), z=st.integers())
+    @example(x=0, y=0, z=0)
+    def test_no_identifier_dunder(self, x: int, y: int, z: int):
+        source_code = """
+from typing import Self
+from opshin.prelude import *
+@dataclass()
+class Foo(PlutusData):
+    a: int
+    b: int
+
+    def __contains__(self, c: int) -> bool:
+        return self.a==c or self.b==c
+
+def validator(a: int, b: int, c:int) -> bool:
+    return c not in Foo(a, b)
 """
         ret = eval_uplc_value(source_code, x, y, z)
         self.assertEqual(ret, z not in [x, y])

--- a/tests/test_class_methods.py
+++ b/tests/test_class_methods.py
@@ -550,3 +550,21 @@ def validator(a: int, b: int, c:int) -> bool:
 """
         ret = eval_uplc_value(source_code, x, y, z)
         self.assertEqual(ret, z not in [x, y])
+
+    def test_no_identifier_method(self):
+        source_code = """
+from typing import Self
+from opshin.prelude import *
+@dataclass()
+class Foo(PlutusData):
+    a: int
+    b: int
+
+    def mul(self, c: int) -> Self:
+        return Foo(a=self.a * c, b=self.b * c)
+
+def validator(a: int, b: int, c:int) -> bool:
+    return Foo(a, b).mul(c).a > 0
+"""
+        ret = eval_uplc_value(source_code, 1, 2, 3)
+        self.assertEqual(ret, True)

--- a/tests/test_std/test_fractions.py
+++ b/tests/test_std/test_fractions.py
@@ -301,3 +301,40 @@ def validator(a: int, b:int, c: int) -> Fraction:
     assert (
         native_fraction_from_oc_fraction(a) * native_fraction_from_oc_fraction(b)
     ) == native_fraction_from_oc_fraction(ret), "invalid mul"
+
+
+@hypothesis.given(hst.integers(), denormalized_fractions)
+def test_radd_dunder(a: int, b: oc_fractions.Fraction):
+    oc_added = a + b
+    oc_normalized = native_fraction_from_oc_fraction(oc_added)
+    assert oc_normalized == (a + native_fraction_from_oc_fraction(b)), "Invalid radd"
+
+
+@hypothesis.given(hst.integers(), denormalized_fractions)
+def test_rsub_dunder(a: int, b: oc_fractions.Fraction):
+    oc_subbed = a - b
+    oc_normalized = native_fraction_from_oc_fraction(oc_subbed)
+    assert oc_normalized == (a - native_fraction_from_oc_fraction(b)), "Invalid rsub"
+
+
+@hypothesis.given(hst.integers(), denormalized_fractions)
+def test_rmul_dunder(a: int, b: oc_fractions.Fraction):
+    oc_mulled = a * b
+    oc_normalized = native_fraction_from_oc_fraction(oc_mulled)
+    assert oc_normalized == (a * native_fraction_from_oc_fraction(b)), "Invalid rmul"
+
+
+@hypothesis.given(hst.integers(), denormalized_fractions_non_null)
+def test_rtruediv_dunder(a: int, b: oc_fractions.Fraction):
+    oc_divved = a / b
+    oc_normalized = native_fraction_from_oc_fraction(oc_divved)
+    assert oc_normalized == (
+        a / native_fraction_from_oc_fraction(b)
+    ), "Invalid rtruediv"
+
+
+@hypothesis.given(hst.integers(), denormalized_fractions_non_null)
+def test_rfloordiv_dunder(a: int, b: oc_fractions.Fraction):
+    oc_floordivved = a // b
+    floordivved = a // native_fraction_from_oc_fraction(b)
+    assert oc_floordivved == floordivved, "Invalid rfloordiv"

--- a/tests/test_std/test_fractions.py
+++ b/tests/test_std/test_fractions.py
@@ -149,6 +149,15 @@ def test_floor_dunder(a: oc_fractions.Fraction, b: oc_fractions.Fraction):
     assert oc_floor == floor, "Invalid floor"
 
 
+@hypothesis.given(denormalized_fractions, hst.integers(max_value=10, min_value=-10))
+def test_pow_dunder(a: oc_fractions.Fraction, b: int):
+    if a == 0:
+        return
+    oc_le = a**b
+    le = native_fraction_from_oc_fraction(a) ** b
+    assert oc_le == le, "Invalid pow"
+
+
 @hypothesis.given(denormalized_fractions)
 def test_ceil(a: oc_fractions.Fraction):
     oc_ceil = oc_fractions.ceil_fraction(a)

--- a/tests/test_std/test_fractions.py
+++ b/tests/test_std/test_fractions.py
@@ -229,6 +229,7 @@ def validator(a: int, b: Fraction) -> Fraction:
 
 
 @hypothesis.given(hst.integers(), denormalized_fractions)
+@hypothesis.example(0, oc_fractions.Fraction(1, 2))
 def test_uplc_mul_int_frac(a, b):
     source_code = """
 from opshin.std.fractions import *
@@ -244,6 +245,7 @@ def validator(a: int, b: Fraction) -> Fraction:
 
 
 @hypothesis.given(denormalized_fractions, hst.integers())
+@hypothesis.example(oc_fractions.Fraction(1, 2), 0)
 def test_uplc_mul_frac_int(a, b):
     source_code = """
 from opshin.std.fractions import *

--- a/tests/test_std/test_fractions.py
+++ b/tests/test_std/test_fractions.py
@@ -275,3 +275,20 @@ def validator(a: Fraction, b: Union[Fraction, int]) -> Fraction:
     assert (
         native_fraction_from_oc_fraction(a) * native_fraction_from_oc_fraction(b)
     ) == native_fraction_from_oc_fraction(ret), "invalid mul"
+
+
+@hypothesis.given(denormalized_fractions, hst.integers())
+@hypothesis.example(oc_fractions.Fraction(1, 2), 0)
+def test_uplc_mul_fractions_unnamed(a: oc_fractions.Fraction, b):
+    source_code = """
+from opshin.std.fractions import *
+from typing import Dict, List, Union
+
+def validator(a: int, b:int, c: int) -> Fraction:
+    return Fraction(a,b) * c
+
+"""
+    ret = eval_uplc(source_code, a.numerator, a.denominator, b)
+    assert (
+        native_fraction_from_oc_fraction(a) * native_fraction_from_oc_fraction(b)
+    ) == native_fraction_from_oc_fraction(ret), "invalid mul"

--- a/tests/test_std/test_fractions.py
+++ b/tests/test_std/test_fractions.py
@@ -1,6 +1,9 @@
 import hypothesis
 import hypothesis.strategies as hst
 from typing import Union
+
+from hypothesis.strategies import integers
+
 from opshin.std import fractions as oc_fractions
 from ..utils import eval_uplc, eval_uplc_value
 
@@ -178,8 +181,10 @@ def test_floor_method(a: oc_fractions.Fraction):
     ), "Invalid ceil"
 
 
-@hypothesis.given(denormalized_fractions, denormalized_fractions)
-def test_uplc(a, b):
+@hypothesis.given(
+    denormalized_fractions, hst.one_of(denormalized_fractions, hst.integers())
+)
+def test_uplc_add_frac_union(a, b):
     source_code = """
 from opshin.std.fractions import *
 from typing import Dict, List, Union
@@ -188,7 +193,83 @@ def validator(a: Fraction, b: Union[Fraction, int]) -> Fraction:
     return a+b
 """
     ret = eval_uplc(source_code, a, b)
-    print(ret)
     assert (
         native_fraction_from_oc_fraction(a) + native_fraction_from_oc_fraction(b)
     ) == native_fraction_from_oc_fraction(ret), "invalid add"
+
+
+@hypothesis.given(denormalized_fractions, hst.integers())
+def test_uplc_add_frac_int(a, b):
+    source_code = """
+from opshin.std.fractions import *
+from typing import Dict, List, Union
+
+def validator(a: Fraction, b: int) -> Fraction:
+    return a+b
+"""
+    ret = eval_uplc(source_code, a, b)
+    assert (
+        native_fraction_from_oc_fraction(a) + b
+    ) == native_fraction_from_oc_fraction(ret), "invalid add"
+
+
+@hypothesis.given(hst.integers(), denormalized_fractions)
+def test_uplc_add_int_frac(a, b):
+    source_code = """
+from opshin.std.fractions import *
+from typing import Dict, List, Union
+
+def validator(a: int, b: Fraction) -> Fraction:
+    return a+b
+"""
+    ret = eval_uplc(source_code, a, b)
+    assert (
+        native_fraction_from_oc_fraction(a) + b
+    ) == native_fraction_from_oc_fraction(ret), "invalid add"
+
+
+@hypothesis.given(hst.integers(), denormalized_fractions)
+def test_uplc_mul_int_frac(a, b):
+    source_code = """
+from opshin.std.fractions import *
+from typing import Dict, List, Union
+
+def validator(a: int, b: Fraction) -> Fraction:
+    return a*b
+"""
+    ret = eval_uplc(source_code, a, b)
+    assert (
+        native_fraction_from_oc_fraction(a) * b
+    ) == native_fraction_from_oc_fraction(ret), "invalid mul"
+
+
+@hypothesis.given(denormalized_fractions, hst.integers())
+def test_uplc_mul_frac_int(a, b):
+    source_code = """
+from opshin.std.fractions import *
+from typing import Dict, List, Union
+
+def validator(a: Fraction, b: int) -> Fraction:
+    return a*b
+"""
+    ret = eval_uplc(source_code, a, b)
+    assert (
+        native_fraction_from_oc_fraction(a) * b
+    ) == native_fraction_from_oc_fraction(ret), "invalid mul"
+
+
+@hypothesis.given(
+    denormalized_fractions, hst.one_of(denormalized_fractions, hst.integers())
+)
+def test_uplc_mul_frac_union(a, b):
+    source_code = """
+from opshin.std.fractions import *
+from typing import Dict, List, Union
+
+def validator(a: Fraction, b: Union[Fraction, int]) -> Fraction:
+    return a*b
+"""
+    ret = eval_uplc(source_code, a, b)
+    assert (
+        native_fraction_from_oc_fraction(a) * native_fraction_from_oc_fraction(b)
+    ) == native_fraction_from_oc_fraction(ret), "invalid mul"


### PR DESCRIPTION
This adds a bunch of test cases and fixes #492 #491 #490 

Most crucially, this now allows for 
1) dunder methods on non-variables (i.e. `Fraction(a,b) * 2` instead of only `a * 2`)
2) reverse dunder methods (radd etc)