### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,7 +54,7 @@ In particular, these steps are performed in the following modules:
 - compilation (Python -> pluthon): `opshin.compiler`
 - building (deriving script address and convenience functions): `opshin.builder`
 
-There are futher `opshin.rewrite` and `opshin.optimize` which perform various rewriting steps (that remove complexity from Python source code) and optimizations (that make sure performance is even better).
+There are further `opshin.rewrite` and `opshin.optimize` which perform various rewriting steps (that remove complexity from Python source code) and optimizations (that make sure performance is even better).
 
 ## Memory
 

--- a/BUG_BOUNTY.md
+++ b/BUG_BOUNTY.md
@@ -16,7 +16,7 @@ The scope of our Bug Bounty Program includes, but is not limited to:
 
 - **Security Vulnerabilities:** Identifying and resolving potential security threats that could compromise the security, correctness or soundness of OpShin compiled smart contracts.
 - **Functional Bugs:** Solbing bugs that affect the functionality of our platform, leading to incorrect behavior or results.
-- **Feature Additions:** Adding new features or enhancements that improve the experience of interacting with the OpShin platoform.
+- **Feature Additions:** Adding new features or enhancements that improve the experience of interacting with the OpShin platform.
 
 Discovered issues and feature suggestions will be tagged with prices directly in the GitHub repository issues of [OpShin](https://github.com/opshin/opshin/issues) or any other part of the [OpShin ecosystem](https://github.com/opshin). These tags represent the monetary value of each task, based on its complexity and impact. The value is paid out to implemented solutions that are proposed as Pull Requests to the respective repository and accepted by a code maintainer.
 
@@ -61,7 +61,7 @@ The categories are (in increasing amount of allocated prize):
 | Minor Issues            | 200 - 400 ADA   | Minor issues with the UX or simple bugs that can be resolved by changing a single function in the source code.                                                                                   | https://github.com/OpShin/opshin/issues/336, https://github.com/OpShin/opshin/issues/338                                             |
 | Medium Issues           | 400 - 2000 ADA  | Most of the issues fall in this category. This covers bugs that require larger code base refactorings or additions of entire features that require additional modules.                           | https://github.com/OpShin/opshin/issues/333, https://github.com/OpShin/opshin/issues/301, https://github.com/OpShin/opshin/issues/68 |
 | Major Issues            | 2000 - 4000 ADA | Entirely independent projects or major components of a platform like an additional website, completely overhauled software architecture etc.                                                     | https://github.com/OpShin/opshin/issues/344, https://github.com/OpShin/opshin/issues/346                                             |
-| Security Vulnerabilites | 3000 - 4000 ADA | Newly discovered inconsistencies in the compiler, violations of the Python semantics preservation guarantee and similar issues that could lead to loss of user funds in production environments. | https://github.com/OpShin/opshin/pull/361, https://github.com/OpShin/opshin/pull/298                                                 |
+| Security Vulnerabilities | 3000 - 4000 ADA | Newly discovered inconsistencies in the compiler, violations of the Python semantics preservation guarantee and similar issues that could lead to loss of user funds in production environments. | https://github.com/OpShin/opshin/pull/361, https://github.com/OpShin/opshin/pull/298                                                 |
 
 ## Report on other Bug Bounty platforms
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ opshin compile_pluto spending examples/smart_contracts/assert_sum.py
 
 Generally, all contributions on the code side are very welcome.
 To get an overview over the architecture and idea behind OpShin, check out [the Technical Documentation](./ARCHITECTURE.md).
-A bug bounty has been set up and funded by Project Catalyst, which awards [Github issue](https://github.com/OpShin/opshin/labels/bug%20bounty) resolution wiht ADA rewards.
+A bug bounty has been set up and funded by Project Catalyst, which awards [Github issue](https://github.com/OpShin/opshin/labels/bug%20bounty) resolution with ADA rewards.
 This is a great opportunity to get involved and earn some ADA.
 Check out the [detailed introduction to the bounty program](./BUG_BOUNTY.md) for more information.
 

--- a/examples/complex_datum.py
+++ b/examples/complex_datum.py
@@ -35,7 +35,7 @@ class BatchOrder(PlutusData):
     CONSTR_ID = 0
     sender: Address
     receiver: Address
-    # If some property might be ommited, just Union with Nothing and check for the instance at runtime!
+    # If some property might be omitted, just Union with Nothing and check for the instance at runtime!
     # Make sure the property is a PlutusData type, if not, wrap it
     receiver_datum_hash: Union[SomeHash, NoHash]
     order_step: OrderStep
@@ -45,7 +45,7 @@ class BatchOrder(PlutusData):
     script_version: bytes
 
 
-# If some parameter might be ommited, just Union with Nothing and check for the instance at runtime!
+# If some parameter might be omitted, just Union with Nothing and check for the instance at runtime!
 def validator(d: Union[Nothing, BatchOrder]) -> bytes:
     print(f"got datum {d}")
     if isinstance(d, Nothing):

--- a/opshin/ledger/api_v3.py
+++ b/opshin/ledger/api_v3.py
@@ -678,7 +678,7 @@ class Publishing(PlutusData):
     custom script. This purpose is also triggered when de-registering such
     stake credentials.
 
-    The index is a 0-based index of the given `Certficate` in `certificates`.
+    The index is a 0-based index of the given `Certificate` in `certificates`.
     """
 
     CONSTR_ID = 3

--- a/opshin/optimize/optimize_const_folding.py
+++ b/opshin/optimize/optimize_const_folding.py
@@ -94,7 +94,7 @@ SAFE_GLOBALS = {x.__name__: x for x in SAFE_GLOBALS_LIST}
 
 
 class ShallowNameDefCollector(CompilingNodeVisitor):
-    step = "Collecting occuring variable names"
+    step = "Collecting occurring variable names"
 
     def __init__(self):
         self.vars = OrderedSet()
@@ -317,7 +317,7 @@ class OptimizeConstantFolding(CompilingNodeTransformer):
             # only evaluate expressions, not statements
             return node
         if isinstance(node, Constant):
-            # prevents unneccessary computations
+            # prevents unnecessary computations
             return node
         try:
             node_source = unparse(node)

--- a/opshin/prelude.py
+++ b/opshin/prelude.py
@@ -9,7 +9,7 @@ class Nothing(PlutusData):
     Example value: Nothing()
     """
 
-    # The maximimum constructor ID for simple cbor types, chosen to minimize probability of collision while keeping the corresponding cbor small
+    # The maximum constructor ID for simple cbor types, chosen to minimize probability of collision while keeping the corresponding cbor small
     CONSTR_ID = 6
 
 

--- a/opshin/prelude_v3.py
+++ b/opshin/prelude_v3.py
@@ -9,7 +9,7 @@ class Nothing(PlutusData):
     Example value: Nothing()
     """
 
-    # The maximimum constructor ID for simple cbor types, chosen to minimize probability of collision while keeping the corresponding cbor small
+    # The maximum constructor ID for simple cbor types, chosen to minimize probability of collision while keeping the corresponding cbor small
     CONSTR_ID = 6
 
 

--- a/opshin/rewrite/rewrite_augassign.py
+++ b/opshin/rewrite/rewrite_augassign.py
@@ -4,7 +4,7 @@ from copy import copy
 from ..util import CompilingNodeTransformer
 
 """
-Rewrites all occurences of augmented assignments
+Rewrites all occurrences of augmented assignments
 into normal assignments.
 """
 

--- a/opshin/rewrite/rewrite_cast_condition.py
+++ b/opshin/rewrite/rewrite_cast_condition.py
@@ -5,7 +5,7 @@ from ast import *
 from ..util import CompilingNodeTransformer
 
 """
-Rewrites all occurences of conditions to an implicit cast to bool
+Rewrites all occurrences of conditions to an implicit cast to bool
 """
 
 SPECIAL_BOOL = "~bool"

--- a/opshin/rewrite/rewrite_comparison_chaining.py
+++ b/opshin/rewrite/rewrite_comparison_chaining.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from ..util import CompilingNodeTransformer
 
 """
-Rewrites all occurences of comparison chaining into normal comparisons.
+Rewrites all occurrences of comparison chaining into normal comparisons.
 """
 
 

--- a/opshin/rewrite/rewrite_tuple_assign.py
+++ b/opshin/rewrite/rewrite_tuple_assign.py
@@ -6,7 +6,7 @@ from ast import *
 from ..util import CompilingNodeTransformer
 
 """
-Rewrites all occurences of assignments to tuples to assignments to single values
+Rewrites all occurrences of assignments to tuples to assignments to single values
 """
 
 

--- a/opshin/std/__init__.py
+++ b/opshin/std/__init__.py
@@ -1,5 +1,5 @@
 """
-OpShin provides a few features in its standard libary.
+OpShin provides a few features in its standard library.
 You can import modules from there (i.e. the `fractions` module) with
 
 ```python

--- a/opshin/std/builtins.py
+++ b/opshin/std/builtins.py
@@ -1,5 +1,5 @@
 """
-A special libary that gives direct access to UPLC built-ins
+A special library that gives direct access to UPLC built-ins
 It is valid code and parts of it may be copied if not all built-ins are required by the user.
 """
 

--- a/opshin/std/integrity.py
+++ b/opshin/std/integrity.py
@@ -1,5 +1,5 @@
 """
-A special libary that gives access to a function that checks the integrity of PlutusDatum objects.
+A special library that gives access to a function that checks the integrity of PlutusDatum objects.
 """
 
 from pycardano import PlutusData

--- a/opshin/type_impls.py
+++ b/opshin/type_impls.py
@@ -76,7 +76,7 @@ class Type:
         """
         Returns a stringified version of the object
 
-        The recursive parameter informs the method whether it was invoked recursively from another invokation
+        The recursive parameter informs the method whether it was invoked recursively from another invocation
         """
         raise NotImplementedError(f"{self.python_type()} can not be stringified")
 
@@ -1126,7 +1126,7 @@ class ListType(ClassType):
                                         "ValueError: Did not find element in list"
                                     ),
                                     plt.Ite(
-                                        # the paramter x must have the same type as the list elements
+                                        # the parameter x must have the same type as the list elements
                                         plt.Apply(
                                             self.typ.cmp(ast.Eq(), self.typ),
                                             OVar("x"),

--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -792,7 +792,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
             assert isinstance(
                 t, Name
             ), "Can only assign to variable names (e.g., x = 5). OpShin does not allow assigning to tuple deconstructors (e.g., a, b = (1, 2)) or to dicts, lists, or members (e.g., x[0] = 1; x.foo = 1)"
-            # Check compatability to previous types -> variable can be bound in a function before and needs to maintain type
+            # Check compatibility to previous types -> variable can be bound in a function before and needs to maintain type
             self.set_variable_type(t.id, typed_ass.value.typ)
         typed_ass.targets = [self.visit(t) for t in node.targets]
         # for deconstructed tuples, check that the size matches
@@ -837,7 +837,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
         assert isinstance(
             node.target, Name
         ), "Can only assign to variable names, no type deconstruction"
-        # Check compatability to previous types -> variable can be bound in a function before and needs to maintain type
+        # Check compatibility to previous types -> variable can be bound in a function before and needs to maintain type
         self.set_variable_type(node.target.id, InstanceType(typed_ass.annotation))
         typed_ass.target = self.visit(node.target)
         assert (
@@ -1455,7 +1455,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
 
     def visit_ListComp(self, node: ListComp) -> TypedListComp:
         typed_listcomp = copy(node)
-        # inside the comprehension is a seperate scope
+        # inside the comprehension is a separate scope
         self.enter_scope()
         # first evaluate generators for assigned variables
         typed_listcomp.generators = [self.visit(s) for s in node.generators]
@@ -1485,7 +1485,7 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
 
     def visit_DictComp(self, node: DictComp) -> TypedDictComp:
         typed_dictcomp = copy(node)
-        # inside the comprehension is a seperate scope
+        # inside the comprehension is a separate scope
         self.enter_scope()
         # first evaluate generators for assigned variables
         typed_dictcomp.generators = [self.visit(s) for s in node.generators]

--- a/opshin/util.py
+++ b/opshin/util.py
@@ -184,7 +184,7 @@ _patterns_cached = {}
 
 
 def make_pattern(structure: plt.AST) -> plt.Pattern:
-    """Creates a shared pattern from the given lambda, cached so that it is re-used in subsequent calls"""
+    """Creates a shared pattern from the given lambda, cached so that it is reused in subsequent calls"""
     structure_serialized = structure.dumps()
     if _patterns_cached.get(structure_serialized) is None:
         # @dataclass
@@ -264,7 +264,7 @@ class NameReadCollector(CompilingNodeVisitor):
         self.visit(node.target)
 
     def visit_FunctionDef(self, node) -> None:
-        # ignore annotations of paramters and return
+        # ignore annotations of parameters and return
         for b in node.body:
             self.visit(b)
 


### PR DESCRIPTION
https://pypi.org/project/codespell

% `codespell --ignore-words-list=cips,nam,notin,ot --skip="*.lock" --write-changes`