### PR TITLE
Enable UPLC-level optimizations in OpShin

### DIFF
--- a/opshin/compiler.py
+++ b/opshin/compiler.py
@@ -9,6 +9,7 @@ from pycardano import PlutusData
 from uplc.ast import data_from_cbor
 
 from .bridge import to_uplc_builtin
+from .optimize.optimize_remove_trace import OptimizeRemoveTrace
 from .prelude import Nothing
 from .type_impls import (
     InstanceType,
@@ -1188,6 +1189,7 @@ def compile(
         RewriteImportUPLCBuiltins(),
         RewriteRemoveTypeStuff(),
         # Apply optimizations
+        OptimizeRemoveTrace() if config.remove_trace else NoOp(),
         OptimizeRemoveDeadvars() if config.remove_dead_code else NoOp(),
         OptimizeRemoveDeadconstants() if config.remove_dead_code else NoOp(),
         OptimizeRemovePass(),

--- a/opshin/optimize/optimize_remove_trace.py
+++ b/opshin/optimize/optimize_remove_trace.py
@@ -1,0 +1,35 @@
+from ast import *
+
+from ..typed_ast import TypedCall, TypedAssert, TypedExpr
+from ..fun_impls import PrintImpl
+from ..type_impls import PolymorphicFunctionInstanceType
+from ..util import CompilingNodeTransformer
+
+"""
+Removes traces in print and assert statements
+"""
+
+
+class OptimizeRemoveTrace(CompilingNodeTransformer):
+    step = (
+        "Removing occurrences of 'print' and 'assert', that use only constant strings"
+    )
+
+    def visit_Assert(self, node: TypedAssert):
+        return TypedAssert(
+            test=node.test,
+            msg=None,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+        )
+
+    def visit_Expr(self, node: TypedExpr):
+        if isinstance(node.value, Call):
+            node_call = node.value
+            if (
+                isinstance(node_call.func.typ, PolymorphicFunctionInstanceType)
+                and isinstance(node_call.func.typ.polymorphic_function, PrintImpl)
+                and all(isinstance(arg, Constant) for arg in node_call.args)
+            ):
+                return None
+        return node

--- a/poetry.lock
+++ b/poetry.lock
@@ -1100,14 +1100,14 @@ zoneinfo = ["tzdata (>=2025.2) ; sys_platform == \"win32\" or sys_platform == \"
 
 [[package]]
 name = "identify"
-version = "2.6.14"
+version = "2.6.15"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "identify-2.6.14-py2.py3-none-any.whl", hash = "sha256:11a073da82212c6646b1f39bb20d4483bfb9543bd5566fec60053c4bb309bf2e"},
-    {file = "identify-2.6.14.tar.gz", hash = "sha256:663494103b4f717cb26921c52f8751363dc89db64364cd836a9bf1535f53cd6a"},
+    {file = "identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757"},
+    {file = "identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf"},
 ]
 
 [package.extras]
@@ -1465,14 +1465,14 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pluthon"
-version = "1.1.4"
+version = "1.2.0"
 description = "Pluto-like programming language for Cardano Smart Contracts in Python"
 optional = false
 python-versions = ">=3"
 groups = ["main"]
 files = [
-    {file = "pluthon-1.1.4-py3-none-any.whl", hash = "sha256:df573b85ac379df741144594ba2c71efd2a119d63382f6b603096eccd8ada810"},
-    {file = "pluthon-1.1.4.tar.gz", hash = "sha256:01985c963afd37ae3bb559681cce00918797247c67bb2968f5aafd0aac53c79d"},
+    {file = "pluthon-1.2.0-py3-none-any.whl", hash = "sha256:d948e9fcb16bf00e29d4854f32ae52e6351f2a242af398acf60ebcb28587837d"},
+    {file = "pluthon-1.2.0.tar.gz", hash = "sha256:e688c621a644a0f225ac538044cad880331619f6df2daafb767e1bdd7f176ce2"},
 ]
 
 [package.dependencies]
@@ -2273,14 +2273,14 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "uplc"
-version = "1.0.13"
+version = "1.1.0"
 description = "Python implementation of untyped plutus language core"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "uplc-1.0.13-py3-none-any.whl", hash = "sha256:6809d72cede9b3da101c59ca74e5253ce31b867b70bdd1928c74dc0649d0167a"},
-    {file = "uplc-1.0.13.tar.gz", hash = "sha256:efcb4a254c95b850871e5c003e738adfb4a46ddce7abd71cbf05643a450c4cbe"},
+    {file = "uplc-1.1.0-py3-none-any.whl", hash = "sha256:0039e7f97280a35ee0abe61159a407ec822662bcbbd36a34f8a00ddc734f7f57"},
+    {file = "uplc-1.1.0.tar.gz", hash = "sha256:c2bcc8803fb7f1714fa9455fdf06e0d2e0812c6adb932d883a7732403134712f"},
 ]
 
 [package.dependencies]
@@ -2550,4 +2550,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.0, <4.0"
-content-hash = "8154f74de1fff98742e156f5f0590925e58734de2be26008f1cde0a321386f0b"
+content-hash = "fab31b6e62673f904e70b762e8b0cfdb604259dabe333da261b356dff72dd5b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ packages = [{include = "opshin"}]
 
 [tool.poetry.dependencies]
 python = ">=3.9.0, <4.0"
-uplc = ">=1.0.13"
-pluthon = ">=1.1.4"
+uplc = ">=1.1.0"
+pluthon = ">=1.2.0"
 pycardano = ">=0.13.0"
 frozenlist2 = ">=1.0.0"
 ordered-set = ">=4.1.0"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -29,6 +29,7 @@ hypothesis.settings.load_profile(PLUTUS_VM_PROFILE)
 from opshin.ledger.api_v2 import *
 
 DEFAULT_CONFIG_FORCE_THREE_PARAMS = DEFAULT_CONFIG.update(force_three_params=True)
+sys.setrecursionlimit(2000)
 
 ALL_EXAMPLES = [
     os.path.join(root, f)


### PR DESCRIPTION
This brings a host of low-level optimizations to opshin, for example pre-evaluating expressions on the level of UPLC, and deduplicating repeated expressions. The result is a significantly shrunken binary size.