### PR TITLE
fix: align int(str) with Python whitespace handling

### DIFF
--- a/opshin/type_impls.py
+++ b/opshin/type_impls.py
@@ -2967,26 +2967,144 @@ class IntImpl(PolymorphicFunction):
                         ("e", plt.EncodeUtf8(OVar("x"))),
                         ("len", plt.LengthOfByteString(OVar("e"))),
                         (
+                            "is_whitespace",
+                            OLambda(
+                                ["b"],
+                                plt.Or(
+                                    plt.Or(
+                                        plt.EqualsInteger(
+                                            OVar("b"), plt.Integer(ord(" "))
+                                        ),
+                                        plt.EqualsInteger(
+                                            OVar("b"), plt.Integer(ord("\t"))
+                                        ),
+                                    ),
+                                    plt.Or(
+                                        plt.Or(
+                                            plt.EqualsInteger(
+                                                OVar("b"), plt.Integer(ord("\n"))
+                                            ),
+                                            plt.EqualsInteger(
+                                                OVar("b"), plt.Integer(ord("\v"))
+                                            ),
+                                        ),
+                                        plt.Or(
+                                            plt.EqualsInteger(
+                                                OVar("b"), plt.Integer(ord("\f"))
+                                            ),
+                                            plt.EqualsInteger(
+                                                OVar("b"), plt.Integer(ord("\r"))
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        (
+                            "strip_left",
+                            plt.RecFun(
+                                OLambda(
+                                    ["f", "i"],
+                                    plt.Ite(
+                                        plt.And(
+                                            plt.LessThanInteger(
+                                                OVar("i"), OVar("len")
+                                            ),
+                                            plt.Apply(
+                                                OVar("is_whitespace"),
+                                                plt.IndexByteString(
+                                                    OVar("e"), OVar("i")
+                                                ),
+                                            ),
+                                        ),
+                                        plt.Apply(
+                                            OVar("f"),
+                                            OVar("f"),
+                                            plt.AddInteger(
+                                                OVar("i"), plt.Integer(1)
+                                            ),
+                                        ),
+                                        OVar("i"),
+                                    ),
+                                )
+                            ),
+                        ),
+                        (
+                            "strip_right",
+                            plt.RecFun(
+                                OLambda(
+                                    ["f", "i"],
+                                    plt.Ite(
+                                        plt.LessThanInteger(
+                                            OVar("i"), plt.Integer(0)
+                                        ),
+                                        OVar("i"),
+                                        plt.Ite(
+                                            plt.Apply(
+                                                OVar("is_whitespace"),
+                                                plt.IndexByteString(
+                                                    OVar("e"), OVar("i")
+                                                ),
+                                            ),
+                                            plt.Apply(
+                                                OVar("f"),
+                                                OVar("f"),
+                                                plt.SubtractInteger(
+                                                    OVar("i"), plt.Integer(1)
+                                                ),
+                                            ),
+                                            OVar("i"),
+                                        ),
+                                    ),
+                                )
+                            ),
+                        ),
+                        ("start", plt.Apply(OVar("strip_left"), plt.Integer(0))),
+                        (
+                            "end",
+                            plt.Apply(
+                                OVar("strip_right"),
+                                plt.SubtractInteger(OVar("len"), plt.Integer(1)),
+                            ),
+                        ),
+                        (
+                            "trimmed_len",
+                            plt.AddInteger(
+                                plt.SubtractInteger(OVar("end"), OVar("start")),
+                                plt.Integer(1),
+                            ),
+                        ),
+                        (
                             "first_int",
                             plt.Ite(
-                                plt.LessThanInteger(plt.Integer(0), OVar("len")),
-                                plt.IndexByteString(OVar("e"), plt.Integer(0)),
+                                plt.LessThanInteger(
+                                    plt.Integer(0), OVar("trimmed_len")
+                                ),
+                                plt.IndexByteString(OVar("e"), OVar("start")),
                                 plt.Integer(ord("_")),
                             ),
                         ),
                         (
                             "last_int",
-                            plt.IndexByteString(
-                                OVar("e"),
-                                plt.SubtractInteger(OVar("len"), plt.Integer(1)),
+                            plt.Ite(
+                                plt.LessThanInteger(
+                                    plt.Integer(0), OVar("trimmed_len")
+                                ),
+                                plt.IndexByteString(OVar("e"), OVar("end")),
+                                plt.Integer(ord("_")),
                             ),
                         ),
                         (
                             "fold_start",
                             OLambda(
-                                ["start"],
+                                ["relative_start"],
                                 plt.FoldList(
-                                    plt.Range(OVar("len"), OVar("start")),
+                                    plt.Range(
+                                        plt.AddInteger(OVar("end"), plt.Integer(1)),
+                                        plt.AddInteger(
+                                            OVar("start"), OVar("relative_start")
+                                        ),
+                                    ),
                                     OLambda(
                                         ["s", "i"],
                                         OLet(
@@ -3038,26 +3156,33 @@ class IntImpl(PolymorphicFunction):
                     ],
                     plt.Ite(
                         plt.Or(
-                            plt.Or(
-                                plt.EqualsInteger(
-                                    OVar("first_int"),
-                                    plt.Integer(ord("_")),
-                                ),
-                                plt.EqualsInteger(
-                                    OVar("last_int"),
-                                    plt.Integer(ord("_")),
-                                ),
+                            plt.LessThanEqualsInteger(
+                                OVar("trimmed_len"), plt.Integer(0)
                             ),
-                            plt.And(
-                                plt.EqualsInteger(OVar("len"), plt.Integer(1)),
+                            plt.Or(
                                 plt.Or(
                                     plt.EqualsInteger(
                                         OVar("first_int"),
-                                        plt.Integer(ord("-")),
+                                        plt.Integer(ord("_")),
                                     ),
                                     plt.EqualsInteger(
-                                        OVar("first_int"),
-                                        plt.Integer(ord("+")),
+                                        OVar("last_int"),
+                                        plt.Integer(ord("_")),
+                                    ),
+                                ),
+                                plt.And(
+                                    plt.EqualsInteger(
+                                        OVar("trimmed_len"), plt.Integer(1)
+                                    ),
+                                    plt.Or(
+                                        plt.EqualsInteger(
+                                            OVar("first_int"),
+                                            plt.Integer(ord("-")),
+                                        ),
+                                        plt.EqualsInteger(
+                                            OVar("first_int"),
+                                            plt.Integer(ord("+")),
+                                        ),
                                     ),
                                 ),
                             ),

--- a/opshin/type_impls.py
+++ b/opshin/type_impls.py
@@ -2988,9 +2988,7 @@ class IntImpl(PolymorphicFunction):
                                     ["f", "i"],
                                     plt.Ite(
                                         plt.And(
-                                            plt.LessThanInteger(
-                                                OVar("i"), OVar("len")
-                                            ),
+                                            plt.LessThanInteger(OVar("i"), OVar("len")),
                                             plt.Apply(
                                                 OVar("is_whitespace"),
                                                 plt.IndexByteString(
@@ -3001,9 +2999,7 @@ class IntImpl(PolymorphicFunction):
                                         plt.Apply(
                                             OVar("f"),
                                             OVar("f"),
-                                            plt.AddInteger(
-                                                OVar("i"), plt.Integer(1)
-                                            ),
+                                            plt.AddInteger(OVar("i"), plt.Integer(1)),
                                         ),
                                         OVar("i"),
                                     ),
@@ -3016,9 +3012,7 @@ class IntImpl(PolymorphicFunction):
                                 OLambda(
                                     ["f", "i"],
                                     plt.Ite(
-                                        plt.LessThanInteger(
-                                            OVar("i"), plt.Integer(0)
-                                        ),
+                                        plt.LessThanInteger(OVar("i"), plt.Integer(0)),
                                         OVar("i"),
                                         plt.Ite(
                                             plt.Apply(

--- a/opshin/type_impls.py
+++ b/opshin/type_impls.py
@@ -2960,6 +2960,17 @@ class IntImpl(PolymorphicFunction):
                 ["x"], plt.IfThenElse(OVar("x"), plt.Integer(1), plt.Integer(0))
             )
         elif isinstance(arg.typ, StringType):
+            whitespace_ordinals = [ord(c) for c in (" ", "\t", "\n", "\v", "\f", "\r")]
+
+            is_whitespace_expr = plt.EqualsInteger(
+                OVar("b"), plt.Integer(whitespace_ordinals[0])
+            )
+            for whitespace_ordinal in whitespace_ordinals[1:]:
+                is_whitespace_expr = plt.Or(
+                    is_whitespace_expr,
+                    plt.EqualsInteger(OVar("b"), plt.Integer(whitespace_ordinal)),
+                )
+
             return OLambda(
                 ["x"],
                 OLet(
@@ -2968,37 +2979,7 @@ class IntImpl(PolymorphicFunction):
                         ("len", plt.LengthOfByteString(OVar("e"))),
                         (
                             "is_whitespace",
-                            OLambda(
-                                ["b"],
-                                plt.Or(
-                                    plt.Or(
-                                        plt.EqualsInteger(
-                                            OVar("b"), plt.Integer(ord(" "))
-                                        ),
-                                        plt.EqualsInteger(
-                                            OVar("b"), plt.Integer(ord("\t"))
-                                        ),
-                                    ),
-                                    plt.Or(
-                                        plt.Or(
-                                            plt.EqualsInteger(
-                                                OVar("b"), plt.Integer(ord("\n"))
-                                            ),
-                                            plt.EqualsInteger(
-                                                OVar("b"), plt.Integer(ord("\v"))
-                                            ),
-                                        ),
-                                        plt.Or(
-                                            plt.EqualsInteger(
-                                                OVar("b"), plt.Integer(ord("\f"))
-                                            ),
-                                            plt.EqualsInteger(
-                                                OVar("b"), plt.Integer(ord("\r"))
-                                            ),
-                                        ),
-                                    ),
-                                ),
-                            ),
+                            OLambda(["b"], is_whitespace_expr),
                         ),
                         (
                             "strip_left",

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -132,8 +132,15 @@ def validator(x: int) -> str:
 
     @given(
         xs=st.one_of(
-            st.builds(lambda x: str(x), st.integers()),
-            st.from_regex(r"\A(?!\s).*(?<!\s)\Z", fullmatch=True),
+            # Python-accepted integer strings wrapped in random ASCII whitespace
+            st.builds(
+                lambda left_ws, x, right_ws: f"{left_ws}{x}{right_ws}",
+                st.text(alphabet=" \t\n\r\v\f", max_size=4),
+                st.integers().map(str),
+                st.text(alphabet=" \t\n\r\v\f", max_size=4),
+            ),
+            # Random ASCII-ish strings to stress rejection/acceptance parity
+            st.text(alphabet="0123456789+-_ abcdefXYZ\t\n\r\v\f", max_size=24),
         )
     )
     @example("")
@@ -147,6 +154,7 @@ def validator(x: int) -> str:
     @example("0\n")
     @example("\t-7\n")
     @example(" 42 ")
+    @example("\r\f+99\v")
     def test_int_string(self, xs: str):
         source_code = """
 def validator(x: str) -> int:

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -144,7 +144,9 @@ def validator(x: int) -> str:
     @example("+123")
     @example("-_")
     @example("0_")
-    # @example("0\n")  # stripping is broken
+    @example("0\n")
+    @example("\t-7\n")
+    @example(" 42 ")
     def test_int_string(self, xs: str):
         source_code = """
 def validator(x: str) -> int:

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -139,8 +139,8 @@ def validator(x: int) -> str:
                 st.integers().map(str),
                 st.text(alphabet=" \t\n\r\v\f", max_size=4),
             ),
-            # Random ASCII-ish strings to stress rejection/acceptance parity
-            st.text(alphabet="0123456789+-_ abcdefXYZ\t\n\r\v\f", max_size=24),
+            # Random ASCII strings to stress rejection/acceptance parity
+            st.text(alphabet=st.characters(max_codepoint=127), max_size=24),
         )
     )
     @example("")
@@ -155,6 +155,12 @@ def validator(x: int) -> str:
     @example("\t-7\n")
     @example(" 42 ")
     @example("\r\f+99\v")
+    @example("+ 1")
+    @example("- 1")
+    @example("1 2")
+    @example("1\t2")
+    @example("+\t1")
+    @example("-\n1")
     def test_int_string(self, xs: str):
         source_code = """
 def validator(x: str) -> int:

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -139,8 +139,13 @@ def validator(x: int) -> str:
                 st.integers().map(str),
                 st.text(alphabet=" \t\n\r\v\f", max_size=4),
             ),
-            # Random ASCII strings to stress rejection/acceptance parity
-            st.text(alphabet=st.characters(max_codepoint=127), max_size=24),
+            # Random Unicode-heavy strings to stress rejection behavior beyond ASCII.
+            st.text(
+                alphabet=st.characters(
+                    blacklist_categories=("Nd", "Zs", "Zl", "Zp", "Cc", "Cs")
+                ),
+                max_size=24,
+            ),
         )
     )
     @example("")

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -140,12 +140,7 @@ def validator(x: int) -> str:
                 st.text(alphabet=" \t\n\r\v\f", max_size=4),
             ),
             # Random Unicode-heavy strings to stress rejection behavior beyond ASCII.
-            st.text(
-                alphabet=st.characters(
-                   
-                ),
-                max_size=24,
-            ),
+            st.text(),
         )
     )
     @example("")

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -142,7 +142,7 @@ def validator(x: int) -> str:
             # Random Unicode-heavy strings to stress rejection behavior beyond ASCII.
             st.text(
                 alphabet=st.characters(
-                    blacklist_categories=("Nd", "Zs", "Zl", "Zp", "Cc", "Cs")
+                   
                 ),
                 max_size=24,
             ),


### PR DESCRIPTION
## Summary
This patch updates `int(str)` conversion to match Python behavior for surrounding whitespace.

### What changed
- Added ASCII whitespace trimming (`space`, `\t`, `\n`, `\v`, `\f`, `\r`) before parsing.
- Kept existing validation semantics for invalid literals.
- Added regression examples in `test_int_string` for:
  - `"0\n"`
  - `"\t-7\n"`
  - `" 42 "`

## Validation
- `python -m pytest tests/test_builtins.py -k test_int_string -q`
- `python -m pytest tests/test_builtins.py -k "test_int_string or test_int_bool or test_int_int" -q`
- `python -m pytest tests/test_builtins.py -q`

Fixes #68
